### PR TITLE
feat: add sonar-js-scan composite action for JS/GAS projects

### DIFF
--- a/sonar-js-scan/action.yml
+++ b/sonar-js-scan/action.yml
@@ -1,0 +1,46 @@
+---
+name: SonarCloud JS/GAS scan
+description: Run SonarCloud scan for JavaScript / Google Apps Script projects
+
+inputs:
+    sonar-token:
+        required: true
+        description: SonarCloud token
+    github-token:
+        required: true
+        description: GitHub token
+    project-key:
+        required: true
+        description: SonarCloud project key (e.g. chrysa_my-project)
+    organization:
+        required: true
+        description: SonarCloud organization slug
+    project-name:
+        required: true
+        description: SonarCloud project display name
+    sources:
+        required: false
+        default: 'src'
+        description: Comma-separated source directories to analyze
+    js-file-suffixes:
+        required: false
+        default: '.js,.gs,.ts,.jsx,.tsx'
+        description: Comma-separated file suffixes recognized as JavaScript/TypeScript
+
+runs:
+    using: composite
+    steps:
+        - name: SonarCloud scan
+          uses: SonarSource/sonarqube-scan-action@v5
+          with:
+              args: >
+                  -Dsonar.projectKey=${{ inputs.project-key }}
+                  -Dsonar.organization=${{ inputs.organization }}
+                  -Dsonar.projectName=${{ inputs.project-name }}
+                  -Dsonar.sources=${{ inputs.sources }}
+                  -Dsonar.sourceEncoding=UTF-8
+                  -Dsonar.javascript.file.suffixes=${{ inputs.js-file-suffixes }}
+                  -Dsonar.exclusions=node_modules/**,**/.git/**,**/__pycache__/**
+          env:
+              GITHUB_TOKEN: ${{ inputs.github-token }}
+              SONAR_TOKEN: ${{ inputs.sonar-token }}


### PR DESCRIPTION
## Summary

Adds a new `sonar-js-scan/` composite action for JavaScript and Google Apps Script projects.

The existing `sonar-scan` action is Python-focused (downloads pytest/ruff/mypy artifacts, passes Python-specific Sonar properties). Non-Python projects cannot use it directly.

## New action: `chrysa/github-actions/sonar-js-scan@main`

**Inputs:**

| Input | Required | Default | Description |
|-------|----------|---------|-------------|
| `sonar-token` | ✅ | — | SonarCloud token |
| `github-token` | ✅ | — | GitHub token |
| `project-key` | ✅ | — | SonarCloud project key |
| `organization` | ✅ | — | SonarCloud org slug |
| `project-name` | ✅ | — | Display name |
| `sources` | ❌ | `src` | Source directories |
| `js-file-suffixes` | ❌ | `.js,.gs,.ts,.jsx,.tsx` | File suffixes for JS/TS detection |

**Usage:**
```yaml
- uses: chrysa/github-actions/sonar-js-scan@main
  with:
    sonar-token: ${{ secrets.SONAR_TOKEN }}
    github-token: ${{ secrets.GITHUB_TOKEN }}
    project-key: chrysa_notion-automation
    organization: chrysa
    project-name: notion-automation
    sources: src
    js-file-suffixes: .js,.gs
```

## Motivation

Needed by chrysa/notion-automation#6 — a Google Apps Script project with `.gs` files that cannot use the Python `sonar-scan` action.