### PR TITLE
feat(sonar-js-scan): add coverage-report-paths and tests inputs

### DIFF
--- a/sonar-js-scan/action.yml
+++ b/sonar-js-scan/action.yml
@@ -22,10 +22,18 @@ inputs:
         required: false
         default: 'src'
         description: Comma-separated source directories to analyze
+    tests:
+        required: false
+        default: 'tests'
+        description: Comma-separated test directories (excluded from analysis)
     js-file-suffixes:
         required: false
         default: '.js,.gs,.ts,.jsx,.tsx'
         description: Comma-separated file suffixes recognized as JavaScript/TypeScript
+    coverage-report-paths:
+        required: false
+        default: ''
+        description: Comma-separated paths to LCOV coverage reports (e.g. coverage/lcov.info)
 
 runs:
     using: composite
@@ -38,9 +46,11 @@ runs:
                   -Dsonar.organization=${{ inputs.organization }}
                   -Dsonar.projectName=${{ inputs.project-name }}
                   -Dsonar.sources=${{ inputs.sources }}
+                  -Dsonar.tests=${{ inputs.tests }}
                   -Dsonar.sourceEncoding=UTF-8
                   -Dsonar.javascript.file.suffixes=${{ inputs.js-file-suffixes }}
                   -Dsonar.exclusions=node_modules/**,**/.git/**,**/__pycache__/**
+                  ${{ inputs.coverage-report-paths != '' && format('-Dsonar.javascript.lcov.reportPaths={0}', inputs.coverage-report-paths) || '' }}
           env:
               GITHUB_TOKEN: ${{ inputs.github-token }}
               SONAR_TOKEN: ${{ inputs.sonar-token }}


### PR DESCRIPTION
## Summary

Add two optional inputs to the `sonar-js-scan` composite action:

- `coverage-report-paths` — LCOV coverage report paths (e.g. `coverage/lcov.info`); passed as `-Dsonar.javascript.lcov.reportPaths` only when non-empty
- `tests` — comma-separated test directories to exclude from analysis (default: `tests`)

## Motivation

Used by [chrysa/satisfactory-automated_calculator](https://github.com/chrysa/satisfactory-automated_calculator) CI which:
1. Runs Jest with `--coverage --coverageReporters=lcov`
2. Uploads `coverage/lcov.info` as a GitHub artifact
3. Downloads it in the `sonar` job and passes it to this action

## Changes

- `sonar-js-scan/action.yml`: add `coverage-report-paths` and `tests` inputs with backward-compatible defaults