### PR TITLE
feat: add sonar-scan-node composite action for TypeScript/JavaScript projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Shared composite GitHub Actions for `chrysa/*` repositories.
 | `chrysa/github-actions/ruff-check@main` | ruff lint + format + JSON report |
 | `chrysa/github-actions/mypy-check@main` | mypy type check + txt report |
 | `chrysa/github-actions/run-tests@main` | pytest + coverage + Codecov |
-| `chrysa/github-actions/sonar-scan@main` | SonarCloud scan |
+| `chrysa/github-actions/sonar-scan@main` | SonarCloud scan (Python) |
+| `chrysa/github-actions/sonar-scan-node@main` | SonarCloud scan (Node.js / TypeScript) |
 
 ## Usage
 

--- a/sonar-scan-node/action.yml
+++ b/sonar-scan-node/action.yml
@@ -1,0 +1,58 @@
+---
+name: SonarCloud scan (Node.js / TypeScript)
+description: Run SonarCloud scan for JavaScript / TypeScript projects
+
+inputs:
+    sonar-token:
+        required: true
+        description: SonarCloud token
+    github-token:
+        required: true
+        description: GitHub token
+    project-key:
+        required: true
+        description: SonarCloud project key (e.g. MyOrg_my-project)
+    organization:
+        required: true
+        description: SonarCloud organization slug
+    project-name:
+        required: true
+        description: SonarCloud project display name
+    sources:
+        required: false
+        default: 'src'
+        description: Source directory
+    tsconfig:
+        required: false
+        default: 'tsconfig.json'
+        description: Path to tsconfig.json for TypeScript analysis
+
+runs:
+    using: composite
+    steps:
+        - name: Download coverage artifact
+          uses: actions/download-artifact@v8
+          with:
+              name: coverage-lcov
+              path: coverage/
+          continue-on-error: true
+
+        - name: List reports available for SonarCloud
+          run: ls -lh coverage/ || echo "coverage/ directory is empty or missing"
+          shell: bash
+
+        - name: SonarCloud Scan
+          uses: SonarSource/sonarqube-scan-action@v5
+          with:
+              args: >
+                  -Dsonar.projectKey=${{ inputs.project-key }}
+                  -Dsonar.organization=${{ inputs.organization }}
+                  -Dsonar.projectName=${{ inputs.project-name }}
+                  -Dsonar.sourceEncoding=UTF-8
+                  -Dsonar.sources=${{ inputs.sources }}
+                  -Dsonar.typescript.tsconfigPath=${{ inputs.tsconfig }}
+                  -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+                  -Dsonar.exclusions=**/node_modules/**,**/dist/**,**/public/**
+          env:
+              GITHUB_TOKEN: ${{ inputs.github-token }}
+              SONAR_TOKEN: ${{ inputs.sonar-token }}


### PR DESCRIPTION
## Summary

Add a new composite action `sonar-scan-node` for running SonarCloud analysis on Node.js / TypeScript projects.

### What it does
- Downloads optional `coverage-lcov` artifact (continue-on-error — gracefully skipped if no tests)
- Runs `SonarSource/sonarqube-scan-action@v5` with TypeScript-specific properties:
  - `sonar.typescript.tsconfigPath`
  - `sonar.javascript.lcov.reportPaths`
  - `sonar.exclusions` for node_modules, dist and public

### Inputs
| Input | Required | Default | Description |
|---|---|---|---|
| `sonar-token` | ✓ | — | SonarCloud token |
| `github-token` | ✓ | — | GitHub token |
| `project-key` | ✓ | — | SonarCloud project key |
| `organization` | ✓ | — | SonarCloud organization slug |
| `project-name` | ✓ | — | Project display name |
| `sources` | — | `src` | Source directory |
| `tsconfig` | — | `tsconfig.json` | Path to tsconfig.json |

### Linked PR
- Forge-Stack-Workshop/react-app-generator — CI update using this action