### PR TITLE
fix(pre-commit): update hook revisions to stable tags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ fail_fast: false
 minimum_pre_commit_version: 4.1.0
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: f1dff44d3a9ae852957f34def96390f28719c232
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer


### PR DESCRIPTION
Replace tree/commit SHAs with proper tag names (v5.0.0, v0.11.2, 0.1.0).

This fixes the `fatal: unable to read tree` error in pre-commit hook checkout.