### PR TITLE
chore: add dependencies-action, PR labeler, and CI standards

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,39 @@
+# Auto-labeling rules for pull requests
+# See: https://github.com/actions/labeler
+
+ci:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '.github/workflows/**'
+                - '.github/dependabot.yml'
+
+pre-commit:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '.pre-commit-config.yaml'
+                - '.pre-commit-hooks.yaml'
+
+documentation:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '*.md'
+                - 'docs/**'
+                - 'README*'
+
+dependencies:
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'pyproject.toml'
+                - 'requirements*.txt'
+                - 'package.json'
+                - 'package-lock.json'
+
+configuration:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '*.toml'
+                - '*.yml'
+                - '*.yaml'
+                - '*.json'
+                - '.env*'
+                - 'Makefile'

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,35 @@
+---
+name: PR Dependency Check
+
+on:
+    pull_request_target:
+        types: [closed, edited, opened, reopened]
+
+permissions:
+    issues: write
+    pull-requests: write
+
+jobs:
+    check_dependencies:
+        runs-on: ubuntu-latest
+        name: Check PR dependencies
+
+        steps:
+            - name: Check dependencies
+              uses: gregsdennis/dependencies-action@main
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Add dependent label
+              if: >-
+                  contains(github.event.pull_request.body, 'depends on') ||
+                  contains(github.event.pull_request.body, 'blocked by')
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      await github.rest.issues.addLabels({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.payload.pull_request.number,
+                        labels: ['dependent'],
+                      });

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+---
+name: PR Labeler
+
+on:
+    pull_request_target:
+        types: [opened, reopened, synchronize]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    labeler:
+        runs-on: ubuntu-latest
+        name: Label PR
+
+        steps:
+            - uses: actions/labeler@v5
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,33 +1,39 @@
+---
 default_language_version:
-  python: python3.14
+    python: python3
 fail_fast: false
 minimum_pre_commit_version: 4.1.0
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: f1dff44d3a9ae852957f34def96390f28719c232
-    hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: f7ed74202ac8ec26bab4a68359556c5243df142f
-    hooks:
-      - id: markdownlint
-        args: [--fix]
-        stages: [manual]
-  - repo: https://github.com/lovesegfault/beautysh
-    rev: 34c3b3da0233e76d7d1ad90a78f3679185ecf31c
-    hooks:
-      - id: beautysh
-        args: [--indent-size, '4']
-  - repo: https://github.com/openstack/bashate
-    rev: ec2f2400915200d633299612a02d7d285e4be24c
-    hooks:
-      - id: bashate
-        args: [--ignore=E006,E020]
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: 50119d658ab48021cad234fc5c8d3253263b2ec0
-    hooks:
-      - id: detect-secrets
-        args: [--baseline, .secrets.baseline]
-        exclude: \.pre-commit-config\.yaml
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: f1dff44d3a9ae852957f34def96390f28719c232
+      hooks:
+          - id: check-json
+          - id: check-yaml
+          - id: trailing-whitespace
+          - id: end-of-file-fixer
+          - id: detect-private-key
+          - id: no-commit-to-branch
+            args: [--branch, main]
+    - repo: https://github.com/igorshubovych/markdownlint-cli
+      rev: f7ed74202ac8ec26bab4a68359556c5243df142f
+      hooks:
+          - id: markdownlint
+            args: [--fix]
+            stages: [manual]
+    - repo: https://github.com/lovesegfault/beautysh
+      rev: 34c3b3da0233e76d7d1ad90a78f3679185ecf31c
+      hooks:
+          - id: beautysh
+            args: [--indent-size, '4']
+    - repo: https://github.com/openstack/bashate
+      rev: ec2f2400915200d633299612a02d7d285e4be24c
+      hooks:
+          - id: bashate
+            args: [--ignore=E006,E020]
+    - repo: https://github.com/chrysa/pre-commit-tools
+      rev: 78d8bd3118110cc9095fcd61eb4772061c3ab628
+      hooks:
+          - id: yaml-sorter
+            exclude: ^\.github/
+          - id: json-sorter
+          - id: env-file-check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# github-actions
+
+## Project Overview
+Reusable GitHub Actions for all chrysa repositories. Provides gitversion, python-setup, ruff-check, sonar-scan, sonar-scan-node, run-tests, tool-setup, install-project actions.
+
+## Repository Structure
+See README.md for detailed structure.
+
+## Development Setup
+```bash
+make install
+make dev
+```
+
+## Testing
+```bash
+make test
+```
+
+## CI/CD
+- Pre-commit hooks: `.pre-commit-config.yaml`
+- CI: `.github/workflows/ci.yml`
+- PR dependency check: `.github/workflows/dependencies.yml`
+- Auto-labeler: `.github/workflows/labeler.yml`
+- Release: `.github/workflows/release.yml`
+
+## Code Standards
+- All commits must follow conventional commit format
+- Pre-commit hooks must pass before push
+- CI must be green before merge
+
+## Git Conventions
+- Branch naming: `feat/`, `fix/`, `chore/`, `refactor/`, `docs/`
+- Commits: conventional commits (`feat:`, `fix:`, `chore:`, etc.)
+- Changelog: auto-generated via `cliff.toml`
+
+## Key Decisions
+See CHANGELOG.md for version history and notable changes.


### PR DESCRIPTION
## Summary

Standardization pass for `chrysa/github-actions`:
- Add `gregsdennis/dependencies-action`, `actions/labeler`
- Add `CLAUDE.md`
- Update `.pre-commit-config.yaml` to use `chrysa/pre-commit-tools`

## Changes

- `.github/workflows/dependencies.yml` — PR dependency check
- `.github/workflows/labeler.yml` — PR auto-labeling
- `.github/labeler.yml` — labeling rules
- `CLAUDE.md` — project context for Claude Code and GitHub Copilot
- `.pre-commit-config.yaml` — add `chrysa/pre-commit-tools` (yaml-sorter, json-sorter, env-file-check); standardize format; remove `detect-secrets` (requires baseline)

## Related

Part of chrysa ecosystem standardization — see `chore/add-dependencies-labeler-ci-standards` across all repos.
