### PR TITLE
fix(ci): stabilize sonar workflow for bot pull requests

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
     sonar:
+        if: ${{ github.event_name != 'pull_request' || github.actor != 'dependabot[bot]' }}
         name: SonarCloud scan
         runs-on: ubuntu-latest
         timeout-minutes: 15


### PR DESCRIPTION
Add Dependabot guard on Sonar job to avoid secret-related failures on bot PRs.