### PR TITLE
fix(sonar-scan): bump sonarqube-scan-action v5 → v8.0.0

### DIFF
--- a/sonar-scan/action.yml
+++ b/sonar-scan/action.yml
@@ -59,7 +59,7 @@ runs:
           shell: bash
 
         - name: SonarCloud Scan
-          uses: SonarSource/sonarqube-scan-action@v5
+          uses: SonarSource/sonarqube-scan-action@v8.0.0
           with:
               args: >
                   -Dsonar.projectKey=${{ inputs.project-key }}


### PR DESCRIPTION
The `sonar-scan` composite action was pinned to `SonarSource/sonarqube-scan-action@v5`.
All standalone `sonar.yml` in the ecosystem already use `@v8.0.0`.
This brings the composite in line with the rest of the ecosystem.