### PR TITLE
fix(sonar): bump sonarqube-scan-action to v8.0.0

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -22,7 +22,7 @@ jobs:
               with:
                   fetch-depth: 0
             - name: SonarCloud scan
-              uses: SonarSource/sonarqube-scan-action@v7
+              uses: SonarSource/sonarqube-scan-action@v8.0.0
               with:
                   args: >
                       -Dsonar.projectKey=chrysa_github-actions


### PR DESCRIPTION
Bump `SonarSource/sonarqube-scan-action` from old version to `v8.0.0` (latest stable) to align with the rest of the chrysa ecosystem.