### PR TITLE
fix(ci): bump sonarqube-scan-action to v8.0.0

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -22,7 +22,7 @@ jobs:
               with:
                   fetch-depth: 0
             - name: SonarCloud scan
-              uses: SonarSource/sonarqube-scan-action@v7
+              uses: SonarSource/sonarqube-scan-action@v8.0.0
               with:
                   args: >
                       -Dsonar.projectKey=chrysa_github-actions


### PR DESCRIPTION
## Summary
Update `SonarSource/sonarqube-scan-action` to v8.0.0 to fix SonarCloud scanner compatibility.

This is a security and compatibility fix — older versions of the scanner are no longer supported by SonarCloud.