### PR TITLE
fix(quality): add docker-test target for CI-compatible action validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ dev: ## No-op for composite actions repo
 
 test: validate ## Run action validation (alias → validate)
 
+docker-test: ## Validate GitHub Actions in Docker (CI-compatible)
+	docker run --rm -v $(PWD):/work -w /work python:3.14-slim sh -c \
+		"pip install --quiet action-validator && action-validator ."
+
 test-cov: validate ## Run action validation (no coverage for actions repo)
 
 lint: validate ## Lint composite actions (alias → validate)


### PR DESCRIPTION
## Changes

- Add `docker-test` Makefile target: validates composite actions via `action-validator` running in Docker (Python 3.14-slim)

This enables CI/CD pipelines to run action validation without requiring `action-validator` installed on the host.