### PR TITLE
fix(ci): add SKIP no-commit-to-branch in pre-commit step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v6
               with:
                   python-version: '3.14'
                   cache: pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
                   cache: pip
 
             - uses: pre-commit/action@v3.0.1
+              env:
+                  SKIP: no-commit-to-branch
 
     validate:
         name: Validate actions YAML


### PR DESCRIPTION
Add SKIP: no-commit-to-branch env to pre-commit step in ci.yml to prevent CI failures when runner is on main