### PR TITLE
fix(sonar-scan): make latest-python, github-token, organization, project-name optional with defaults

### DIFF
--- a/sonar-scan/action.yml
+++ b/sonar-scan/action.yml
@@ -1,79 +1,71 @@
----
-name: SonarCloud scan
 description: Download analysis reports and run SonarCloud scan
-
 inputs:
-    latest-python:
-        required: true
-        description: Latest Python version (artifact name + sonar python version)
-    sonar-token:
-        required: true
-        description: SonarCloud token
-    github-token:
-        required: true
-        description: GitHub token
-    project-key:
-        required: true
-        description: SonarCloud project key (e.g. chrysa_my-project)
-    organization:
-        required: true
-        description: SonarCloud organization slug
-    project-name:
-        required: true
-        description: SonarCloud project display name
-    sources:
-        required: false
-        default: 'src'
-        description: Comma-separated source directories
-    tests:
-        required: false
-        default: 'tests'
-        description: Comma-separated test directories
-
+  github-token:
+    default: ''
+    description: GitHub token (for PR decoration)
+    required: false
+  latest-python:
+    default: '3.12'
+    description: Latest Python version (artifact name + sonar python version)
+    required: false
+  organization:
+    default: chrysa
+    description: SonarCloud organization slug
+    required: false
+  project-key:
+    description: SonarCloud project key (e.g. chrysa_my-project)
+    required: true
+  project-name:
+    default: ''
+    description: SonarCloud project display name (defaults to project-key)
+    required: false
+  sonar-token:
+    description: SonarCloud token
+    required: true
+  sources:
+    default: .
+    description: Comma-separated source directories
+    required: false
+  tests:
+    default: tests
+    description: Comma-separated test directories
+    required: false
+name: SonarCloud scan
 runs:
-    using: composite
-    steps:
-        - name: Download test results (${{ inputs.latest-python }})
-          uses: actions/download-artifact@v8
-          with:
-              name: test-results-${{ inputs.latest-python }}
-              path: reports/
-          continue-on-error: true
+  steps:
+  - continue-on-error: true
+    name: Download test results (${{ inputs.latest-python }})
+    uses: actions/download-artifact@v8
+    with:
+      name: test-results-${{ inputs.latest-python }}
+      path: reports/
+  - continue-on-error: true
+    name: Download ruff report
+    uses: actions/download-artifact@v8
+    with:
+      name: ruff-report
+      path: reports/
+  - continue-on-error: true
+    name: Download mypy report
+    uses: actions/download-artifact@v8
+    with:
+      name: mypy-report
+      path: reports/
+  - name: List reports available for SonarCloud
+    run: ls -lh reports/ || echo "reports/ directory is empty or missing"
+    shell: bash
+  - env:
+      GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
+      SONAR_TOKEN: ${{ inputs.sonar-token }}
+    name: SonarCloud Scan
+    uses: SonarSource/sonarqube-scan-action@v8.0.0
+    with:
+      args: '-Dsonar.projectKey=${{ inputs.project-key }} -Dsonar.organization=${{
+        inputs.organization }} -Dsonar.projectName=${{ inputs.project-name || inputs.project-key
+        }} -Dsonar.sourceEncoding=UTF-8 -Dsonar.sources=${{ inputs.sources }} -Dsonar.tests=${{
+        inputs.tests }} -Dsonar.python.version=${{ inputs.latest-python }} -Dsonar.python.coverage.reportPaths=reports/coverage.xml
+        -Dsonar.python.ruff.reportPaths=reports/ruff.json -Dsonar.python.mypy.reportPaths=reports/mypy.txt
+        -Dsonar.python.xunit.reportPath=reports/junit.xml -Dsonar.exclusions=**/__pycache__/**,**/*.egg-info/**,**/.git/**
 
-        - name: Download ruff report
-          uses: actions/download-artifact@v8
-          with:
-              name: ruff-report
-              path: reports/
-          continue-on-error: true
-
-        - name: Download mypy report
-          uses: actions/download-artifact@v8
-          with:
-              name: mypy-report
-              path: reports/
-          continue-on-error: true
-
-        - name: List reports available for SonarCloud
-          run: ls -lh reports/ || echo "reports/ directory is empty or missing"
-          shell: bash
-
-        - name: SonarCloud Scan
-          uses: SonarSource/sonarqube-scan-action@v8.0.0
-          with:
-              args: >
-                  -Dsonar.projectKey=${{ inputs.project-key }}
-                  -Dsonar.organization=${{ inputs.organization }}
-                  -Dsonar.projectName=${{ inputs.project-name }}
-                  -Dsonar.sourceEncoding=UTF-8
-                  -Dsonar.sources=${{ inputs.sources }}
-                  -Dsonar.tests=${{ inputs.tests }}
-                  -Dsonar.python.version=${{ inputs.latest-python }}
-                  -Dsonar.python.coverage.reportPaths=reports/coverage.xml
-                  -Dsonar.python.ruff.reportPaths=reports/ruff.json
-                  -Dsonar.python.mypy.reportPaths=reports/mypy.txt
-                  -Dsonar.python.xunit.reportPath=reports/junit.xml
-                  -Dsonar.exclusions=**/__pycache__/**,**/*.egg-info/**,**/.git/**
-          env:
-              GITHUB_TOKEN: ${{ inputs.github-token }}
-              SONAR_TOKEN: ${{ inputs.sonar-token }}
+        '
+  using: composite


### PR DESCRIPTION
## Problem

The `sonar-scan` composite action had 4 required inputs that were not being passed by the generated `sonar.yml` files across all repos:
- `latest-python` — required, no default
- `github-token` — required, no default
- `organization` — required, no default
- `project-name` — required, no default

This caused CI failures because the caller only passes `sonar-token`, `project-key`, `sources`, and `tests`.

## Fix

Made all 4 inputs optional with sensible defaults:
- `latest-python`: default `'3.12'`
- `github-token`: default `''` (falls back to `github.token` in the action via `|| github.token`)
- `organization`: default `'chrysa'`
- `project-name`: default `''` (falls back to `inputs.project-key` via `|| inputs.project-key`)

Also updated `sources` default from `src` to `.` to better match repos without a `src/` layout.