### PR TITLE
fix(sonar-scan): downgrade sonarqube-scan-action v8/v5 → v4.2.1 + make sonar-scan-node inputs optional

### DIFF
--- a/sonar-scan-node/action.yml
+++ b/sonar-scan-node/action.yml
@@ -1,58 +1,54 @@
----
-name: SonarCloud scan (Node.js / TypeScript)
 description: Run SonarCloud scan for JavaScript / TypeScript projects
-
 inputs:
-    sonar-token:
-        required: true
-        description: SonarCloud token
-    github-token:
-        required: true
-        description: GitHub token
-    project-key:
-        required: true
-        description: SonarCloud project key (e.g. MyOrg_my-project)
-    organization:
-        required: true
-        description: SonarCloud organization slug
-    project-name:
-        required: true
-        description: SonarCloud project display name
-    sources:
-        required: false
-        default: 'src'
-        description: Source directory
-    tsconfig:
-        required: false
-        default: 'tsconfig.json'
-        description: Path to tsconfig.json for TypeScript analysis
-
+  github-token:
+    default: ''
+    description: GitHub token (optional, used for PR decoration)
+    required: false
+  organization:
+    default: chrysa
+    description: SonarCloud organization slug
+    required: false
+  project-key:
+    description: SonarCloud project key (e.g. MyOrg_my-project)
+    required: true
+  project-name:
+    default: ''
+    description: SonarCloud project display name (defaults to project-key if empty)
+    required: false
+  sonar-token:
+    description: SonarCloud token
+    required: true
+  sources:
+    default: src
+    description: Source directory
+    required: false
+  tsconfig:
+    default: tsconfig.json
+    description: Path to tsconfig.json for TypeScript analysis
+    required: false
+name: SonarCloud scan (Node.js / TypeScript)
 runs:
-    using: composite
-    steps:
-        - name: Download coverage artifact
-          uses: actions/download-artifact@v8
-          with:
-              name: coverage-lcov
-              path: coverage/
-          continue-on-error: true
+  steps:
+  - continue-on-error: true
+    name: Download coverage artifact
+    uses: actions/download-artifact@v8
+    with:
+      name: coverage-lcov
+      path: coverage/
+  - name: List reports available for SonarCloud
+    run: ls -lh coverage/ || echo "coverage/ directory is empty or missing"
+    shell: bash
+  - env:
+      GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
+      SONAR_TOKEN: ${{ inputs.sonar-token }}
+    name: SonarCloud Scan
+    uses: SonarSource/sonarqube-scan-action@v4.2.1
+    with:
+      args: '-Dsonar.projectKey=${{ inputs.project-key }} -Dsonar.organization=${{
+        inputs.organization }} -Dsonar.projectName=${{ inputs.project-name || inputs.project-key
+        }} -Dsonar.sourceEncoding=UTF-8 -Dsonar.sources=${{ inputs.sources }} -Dsonar.typescript.tsconfigPath=${{
+        inputs.tsconfig }} -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+        -Dsonar.exclusions=**/node_modules/**,**/dist/**,**/public/**
 
-        - name: List reports available for SonarCloud
-          run: ls -lh coverage/ || echo "coverage/ directory is empty or missing"
-          shell: bash
-
-        - name: SonarCloud Scan
-          uses: SonarSource/sonarqube-scan-action@v5
-          with:
-              args: >
-                  -Dsonar.projectKey=${{ inputs.project-key }}
-                  -Dsonar.organization=${{ inputs.organization }}
-                  -Dsonar.projectName=${{ inputs.project-name }}
-                  -Dsonar.sourceEncoding=UTF-8
-                  -Dsonar.sources=${{ inputs.sources }}
-                  -Dsonar.typescript.tsconfigPath=${{ inputs.tsconfig }}
-                  -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
-                  -Dsonar.exclusions=**/node_modules/**,**/dist/**,**/public/**
-          env:
-              GITHUB_TOKEN: ${{ inputs.github-token }}
-              SONAR_TOKEN: ${{ inputs.sonar-token }}
+        '
+  using: composite

--- a/sonar-scan/action.yml
+++ b/sonar-scan/action.yml
@@ -58,7 +58,7 @@ runs:
       GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
       SONAR_TOKEN: ${{ inputs.sonar-token }}
     name: SonarCloud Scan
-    uses: SonarSource/sonarqube-scan-action@v8.0.0
+    uses: SonarSource/sonarqube-scan-action@v4.2.1
     with:
       args: '-Dsonar.projectKey=${{ inputs.project-key }} -Dsonar.organization=${{
         inputs.organization }} -Dsonar.projectName=${{ inputs.project-name || inputs.project-key


### PR DESCRIPTION
## Summary

### Problems fixed
- `sonar-scan/action.yml`: `sonarqube-scan-action@v8.0.0` → `@v4.2.1` (billing-broken version)
- `sonar-scan-node/action.yml`: `sonarqube-scan-action@v5` → `@v4.2.1`
- `sonar-scan-node/action.yml`: `github-token`, `organization`, `project-name` made optional (with `organization` defaulting to `chrysa`)

### Impact
27 repos across the ecosystem now use `chrysa/github-actions/sonar-scan@v1`. Once this fix is merged and the `v1` floating tag is updated, all repos will use the working version automatically without any change on their side.