### PR TITLE
chore(sonar-scan): add DEPRECATED notice — migrate to sonar-scan-python

### DIFF
--- a/sonar-scan/action.yml
+++ b/sonar-scan/action.yml
@@ -1,4 +1,6 @@
-description: Download analysis reports and run SonarCloud scan
+# DEPRECATED — use sonar-scan-python@v1 instead (see chrysa/github-actions#43).
+# This action is kept for backward compatibility until all ecosystem repos migrate.
+description: '[DEPRECATED] Download analysis reports and run SonarCloud scan — use sonar-scan-python@v1'
 inputs:
   github-token:
     default: ''


### PR DESCRIPTION
## Summary

Refs #43

Adds a `DEPRECATED` notice to `sonar-scan/action.yml`.

## Context

Issue #43 tracks the full migration from `sonar-scan@v1` to `sonar-scan-python@v1`.
The action version was already fixed to `v4.2.1` in PR #44.

This PR handles the first task from #43:
> ✅ Add a `DEPRECATED` note in `sonar-scan/action.yml` description pointing to `sonar-scan-python`

## Remaining work (tracked in #43)

- [ ] Migrate all ecosystem repos from `sonar-scan@v1` to `sonar-scan-python@v1`
- [ ] After full migration: archive or remove `sonar-scan`
- [ ] Align scanner version audit across all 4 sonar actions