### PR TITLE
feat(ruff-check,run-tests): add working-directory input for monorepo support

### DIFF
--- a/ruff-check/action.yml
+++ b/ruff-check/action.yml
@@ -16,6 +16,10 @@ inputs:
     sources:
         required: true
         description: Space-separated source paths to check (e.g. 'src tests')
+    working-directory:
+        required: false
+        default: '.'
+        description: Working directory to run ruff from (e.g. backend for monorepos)
 
 runs:
     using: composite
@@ -24,6 +28,7 @@ runs:
           env:
               RUFF_CONFIG: ${{ inputs.config }}
               RUFF_SOURCES: ${{ inputs.sources }}
+          working-directory: ${{ inputs.working-directory }}
           run: ruff check --config="${RUFF_CONFIG}" ${RUFF_SOURCES}
           shell: bash
 
@@ -31,6 +36,7 @@ runs:
           env:
               RUFF_CONFIG: ${{ inputs.config }}
               RUFF_SOURCES: ${{ inputs.sources }}
+          working-directory: ${{ inputs.working-directory }}
           run: ruff format --check --config="${RUFF_CONFIG}" ${RUFF_SOURCES}
           shell: bash
 
@@ -39,6 +45,7 @@ runs:
           env:
               RUFF_CONFIG: ${{ inputs.config }}
               RUFF_SOURCES: ${{ inputs.sources }}
+          working-directory: ${{ inputs.working-directory }}
           run: |
               mkdir -p reports
               ruff check --config="${RUFF_CONFIG}" --output-format=json ${RUFF_SOURCES} > reports/ruff.json || true
@@ -50,4 +57,4 @@ runs:
           uses: actions/upload-artifact@v7
           with:
               name: ruff-report
-              path: reports/ruff.json
+              path: ${{ inputs.working-directory }}/reports/ruff.json

--- a/run-tests/action.yml
+++ b/run-tests/action.yml
@@ -12,6 +12,10 @@ inputs:
     cov-module:
         required: true
         description: Python module name to measure coverage for (e.g. pre_commit_hooks)
+    working-directory:
+        required: false
+        default: '.'
+        description: Working directory to run pytest from (e.g. backend for monorepos)
 
 runs:
     using: composite
@@ -19,6 +23,7 @@ runs:
         - name: Run test suite
           env:
               COV_MODULE: ${{ inputs.cov-module }}
+          working-directory: ${{ inputs.working-directory }}
           run: |
               mkdir -p reports
               pytest \
@@ -35,13 +40,13 @@ runs:
           uses: actions/upload-artifact@v7
           with:
               name: test-results-${{ inputs.python-version }}
-              path: reports/
+              path: ${{ inputs.working-directory }}/reports/
 
         - name: Publish test results to PR
           if: always() && inputs.python-version == inputs.latest-python
           uses: EnricoMi/publish-unit-test-result-action@v2
           with:
-              files: reports/junit.xml
+              files: ${{ inputs.working-directory }}/reports/junit.xml
               comment_title: Test Results
               check_name: pytest
 
@@ -49,5 +54,5 @@ runs:
           if: inputs.python-version == inputs.latest-python
           uses: codecov/codecov-action@v6
           with:
-              files: reports/coverage.xml
+              files: ${{ inputs.working-directory }}/reports/coverage.xml
               fail_ci_if_error: false


### PR DESCRIPTION
Add optional `working-directory` input (default: `.`) to `ruff-check` and `run-tests`.

Closes #47
Closes #46