### PR TITLE
chore: migrate sonar-scan to sonar-scan-python

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -33,9 +33,13 @@ jobs:
               with:
                   fetch-depth: 0
             - name: SonarCloud scan
-              uses: chrysa/github-actions/sonar-scan@v1
+              uses: chrysa/github-actions/sonar-scan-python@v1
               with:
+                  python-version: "3.14"
                   sonar-token: ${{ secrets.SONAR_TOKEN }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
                   project-key: chrysa_github-actions
+                  organization: chrysa
+                  project-name: github-actions
                   sources: .
                   tests: tests


### PR DESCRIPTION
Migrate self CI from `sonar-scan@v1` to `sonar-scan-python@v1`.

Closes #43