### PR TITLE
fix(yaml): quote run values containing :all: to prevent YAML parsing errors

### DIFF
--- a/.github/workflows/auto-update-pre-commit.yml
+++ b/.github/workflows/auto-update-pre-commit.yml
@@ -23,7 +23,7 @@ jobs:
               with:
                   python-version: '3.14'
             - name: Install pre-commit
-              run: pip install --only-binary :all: --upgrade pre-commit
+              run: "pip install --only-binary :all: --upgrade pre-commit"
             - name: Autoupdate hooks
               run: pre-commit autoupdate
             - name: Open PR if changes

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
                   python-version: '3.14'
 
             - name: Install MkDocs
-              run: pip install --only-binary :all: mkdocs-material
+              run: "pip install --only-binary :all: mkdocs-material"
 
             - name: Build site
               run: mkdocs build

--- a/publish-python-package/action.yml
+++ b/publish-python-package/action.yml
@@ -1,60 +1,51 @@
----
-name: Publish Python package
 description: Build and publish a Python package to PyPI using hatch or setuptools
-
 inputs:
-    pypi-token:
-        required: true
-        description: PyPI API token for authentication
-    build-backend:
-        required: false
-        default: 'hatch'
-        description: Build backend to use (hatch or setuptools)
-    python-version:
-        required: false
-        default: '3.14'
-        description: Python version for build environment
-    repository-url:
-        required: false
-        default: 'https://upload.pypi.org/legacy/'
-        description: PyPI repository URL (use https://test.pypi.org/legacy/ for TestPyPI)
-
+  build-backend:
+    default: hatch
+    description: Build backend to use (hatch or setuptools)
+    required: false
+  pypi-token:
+    description: PyPI API token for authentication
+    required: true
+  python-version:
+    default: '3.14'
+    description: Python version for build environment
+    required: false
+  repository-url:
+    default: https://upload.pypi.org/legacy/
+    description: PyPI repository URL (use https://test.pypi.org/legacy/ for TestPyPI)
+    required: false
+name: Publish Python package
 runs:
-    using: composite
-    steps:
-        - name: Set up Python
-          uses: actions/setup-python@v6
-          with:
-              python-version: ${{ inputs.python-version }}
-
-        - name: Install build tools (hatch)
-          if: inputs.build-backend == 'hatch'
-          run: pip install --only-binary :all: --upgrade hatch twine
-          shell: bash
-
-        - name: Install build tools (setuptools)
-          if: inputs.build-backend == 'setuptools'
-          run: pip install --only-binary :all: --upgrade build twine
-          shell: bash
-
-        - name: Build package (hatch)
-          if: inputs.build-backend == 'hatch'
-          run: hatch build
-          shell: bash
-
-        - name: Build package (setuptools)
-          if: inputs.build-backend == 'setuptools'
-          run: python -m build
-          shell: bash
-
-        - name: Check package with twine
-          run: twine check dist/*
-          shell: bash
-
-        - name: Publish to PyPI
-          run: twine upload dist/*
-          shell: bash
-          env:
-              TWINE_USERNAME: __token__
-              TWINE_PASSWORD: ${{ inputs.pypi-token }}
-              TWINE_REPOSITORY_URL: ${{ inputs.repository-url }}
+  steps:
+  - name: Set up Python
+    uses: actions/setup-python@v6
+    with:
+      python-version: ${{ inputs.python-version }}
+  - if: inputs.build-backend == 'hatch'
+    name: Install build tools (hatch)
+    run: 'pip install --only-binary :all: --upgrade hatch twine'
+    shell: bash
+  - if: inputs.build-backend == 'setuptools'
+    name: Install build tools (setuptools)
+    run: 'pip install --only-binary :all: --upgrade build twine'
+    shell: bash
+  - if: inputs.build-backend == 'hatch'
+    name: Build package (hatch)
+    run: hatch build
+    shell: bash
+  - if: inputs.build-backend == 'setuptools'
+    name: Build package (setuptools)
+    run: python -m build
+    shell: bash
+  - name: Check package with twine
+    run: twine check dist/*
+    shell: bash
+  - env:
+      TWINE_PASSWORD: ${{ inputs.pypi-token }}
+      TWINE_REPOSITORY_URL: ${{ inputs.repository-url }}
+      TWINE_USERNAME: __token__
+    name: Publish to PyPI
+    run: twine upload dist/*
+    shell: bash
+  using: composite

--- a/python-setup/action.yml
+++ b/python-setup/action.yml
@@ -1,24 +1,19 @@
----
-name: Setup Python
 description: Set up Python, print version and upgrade pip
-
 inputs:
-    python-version:
-        required: true
-        description: Python version to set up
-
+  python-version:
+    description: Python version to set up
+    required: true
+name: Setup Python
 runs:
-    using: composite
-    steps:
-        - name: Set up Python ${{ inputs.python-version }}
-          uses: actions/setup-python@v6
-          with:
-              python-version: ${{ inputs.python-version }}
-
-        - name: Check Python version
-          run: python --version
-          shell: bash
-
-        - name: Upgrade pip
-          run: python -m pip install --only-binary :all: --upgrade pip
-          shell: bash
+  steps:
+  - name: Set up Python ${{ inputs.python-version }}
+    uses: actions/setup-python@v6
+    with:
+      python-version: ${{ inputs.python-version }}
+  - name: Check Python version
+    run: python --version
+    shell: bash
+  - name: Upgrade pip
+    run: 'python -m pip install --only-binary :all: --upgrade pip'
+    shell: bash
+  using: composite


### PR DESCRIPTION
## Problem

In GitHub Actions composite actions YAML, a `run:` value containing `--only-binary :all:` triggers a YAML parsing error: `:all: ` (colon followed by space) is interpreted as a mapping key separator in plain scalars.

Broke all jobs using `python-setup` and `publish-python-package` with:
```
Set up job → failure
```

## Fix

Wrap affected `run:` values in single quotes:

- `python-setup/action.yml`
- `publish-python-package/action.yml`
- `.github/workflows/pages.yml`
- `.github/workflows/auto-update-pre-commit.yml`

## Validation

All 4 files validated YAML-valid. Unblocks chrysa/guideline-checker#69.