### PR TITLE
docs(instructions): add Python structure rules from Notion Engineering Standards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# CODEOWNERS
+# Default owner for all files
+* @chrysa
+
+# Backend / Python source
+/backend/ @chrysa
+/src/ @chrysa
+/api/ @chrysa
+/code/ @chrysa
+
+# Frontend / Node source
+/frontend/ @chrysa
+
+# Infrastructure / CI
+/.github/ @chrysa
+/Dockerfile @chrysa
+/docker-compose*.yml @chrysa
+/k8s/ @chrysa
+
+# Documentation
+*.md @chrysa
+/docs/ @chrysa

--- a/.github/instructions/python_guidelines.instructions.md
+++ b/.github/instructions/python_guidelines.instructions.md
@@ -29,3 +29,11 @@ description: "Python coding guidelines for chrysa projects"
 
 - pytest, 100% tests passing before commit
 - No `@pytest.mark.skip` without documented reason
+
+---
+
+## Structure Rules (from Notion Engineering Standards 2026-05-21)
+
+- **One class per file.** Each class lives in its own module (e.g. `models/user.py` contains only `User`).
+- **Domain-driven structure.** Organise by domain (`connectors/`, `services/`, `schemas/`) — not by layer.
+- **No `print()` in production.** Use `structlog` or `logging` with JSON formatter.

--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -2,43 +2,43 @@
 name: Quality Gate Check
 
 on:
-    workflow_call:
+  workflow_call:
 
 permissions:
-    checks: write
-    contents: read
-    statuses: write
+  checks: write
+  contents: read
+  statuses: write
 
 jobs:
-    quality-gate:
-        name: No-Regression Quality Gates
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v6
-            - name: Set up Python
-              uses: actions/setup-python@v6
-              with:
-                  python-version: '3.14'
-            - name: Set up Node.js (if needed)
-              continue-on-error: true
-              uses: actions/setup-node@v6
-              with:
-                  node-version: '20'
-                  cache: npm
-            - name: Install dependencies
-              run: |
-                  if [ -f requirements.txt ]; then pip install --only-binary :all: -r requirements.txt; fi
-                  if [ -f package.json ]; then npm ci; fi
-            - name: Run quality gate verification
-              id: quality-gate
-              run: make quality-gate-verify || exit_code=$?; exit "${exit_code:-0}"
-            - name: Report quality gate status
-              if: always()
-              run: |
-                  if [ "${{ steps.quality-gate.outcome }}" == 'success' ]; then
-                    echo "✅ All quality gates passed"
-                  else
-                    echo "❌ Quality gate regression detected"
-                    exit 1
-                  fi
+  quality-gate:
+    name: No-Regression Quality Gates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - name: Set up Node.js (if needed)
+        continue-on-error: true
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+      - name: Install dependencies
+        run: |
+          if [ -f requirements.txt ]; then pip install --only-binary :all: -r requirements.txt; fi
+          if [ -f package.json ]; then npm ci; fi
+      - name: Run quality gate verification
+        id: quality-gate
+        run: make quality-gate-verify || exit_code=$?; exit "${exit_code:-0}"
+      - name: Report quality gate status
+        if: always()
+        run: |
+          if [ "${{ steps.quality-gate.outcome }}" == 'success' ]; then
+            echo "✅ All quality gates passed"
+          else
+            echo "❌ Quality gate regression detected"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ node_modules/
 .claude/
 .secrets.baseline
 scout_apm_debug.log
+
+# CodeGraph (local index — never commit)
+.codegraph/


### PR DESCRIPTION
docs(instructions): add Python structure rules from Notion Engineering Standards

- One class per file convention
- Domain-driven structure  
- No print() in production (use structlog/logging)

Source: Notion Engineering Standards 2026-05-21