### PR TITLE
fix(sonar-scan-python): upgrade sonarqube-scan-action from v5 to v8

### DIFF
--- a/sonar-scan-python/action.yml
+++ b/sonar-scan-python/action.yml
@@ -71,7 +71,7 @@ runs:
       GITHUB_TOKEN: ${{ inputs.github-token }}
       SONAR_TOKEN: ${{ inputs.sonar-token }}
     name: SonarCloud Scan
-    uses: SonarSource/sonarqube-scan-action@v5
+    uses: SonarSource/sonarqube-scan-action@v8
     with:
       args: '-Dsonar.projectKey=${{ inputs.project-key }} -Dsonar.organization=${{
         inputs.organization }} -Dsonar.projectName=${{ inputs.project-name }} -Dsonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

Upgrade `SonarSource/sonarqube-scan-action` from `@v5` to `@v8` in the `sonar-scan-python` composite action.

### Motivation

`@v5` is deprecated and contains a security vulnerability (as flagged by GitHub Actions runner warnings). `@v8` is the latest stable version, consistent with the version already used in this repo's own `sonar.yml` workflow.

### Impact

Fixes CI failure in downstream repos using `chrysa/github-actions/sonar-scan-python@main` — previously receiving `Error 404 on api.sonarcloud.io/analysis/analyses` due to the outdated scanner engine in `@v5`.