### PR TITLE
fix(sonar-scan-python): pin scanner to 5.0.1.3006 to avoid /analysis/analyses 404

### DIFF
--- a/sonar-scan-python/action.yml
+++ b/sonar-scan-python/action.yml
@@ -73,6 +73,7 @@ runs:
     name: SonarCloud Scan
     uses: SonarSource/sonarqube-scan-action@v8
     with:
+      scannerVersion: 5.0.1.3006
       args: '-Dsonar.projectKey=${{ inputs.project-key }} -Dsonar.organization=${{
         inputs.organization }} -Dsonar.projectName=${{ inputs.project-name }} -Dsonar.sourceEncoding=UTF-8
         -Dsonar.sources=${{ inputs.sources }} ${{ inputs.tests != '''' && format(''-Dsonar.tests={0}'',


### PR DESCRIPTION
## Summary

Pin the SonarScanner CLI version to **5.0.1.3006** in the `sonar-scan-python` composite action.

### Root Cause

SonarScanner 8.x (default of `sonarqube-scan-action@v8`) uses a new `/analysis/analyses` API endpoint to register analyses before scanning. This endpoint is **not available on SonarCloud Community plans**, causing:

```
ERROR Error during SonarScanner Engine execution
java.lang.IllegalStateException: Unable to create analysis
HttpException: Error 404 on https://api.sonarcloud.io/analysis/analyses
```

### Fix

Override `scannerVersion: 5.0.1.3006` so the action uses the last stable 5.x scanner which doesn't call the new endpoint — while keeping the **action itself at v8** to comply with security requirements (v5 was deprecated/insecure per GitHub Actions annotations).