### PR TITLE
chore(pre-commit): bump pre-commit-tools to v0.1.1-76, add regression-gate hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,9 +32,11 @@ repos:
           - id: bashate
             args: [--ignore=E006,E020]
     - repo: https://github.com/chrysa/pre-commit-tools
-      rev: v0.1.1-73
+      rev: v0.1.1-76
       hooks:
           - id: yaml-sorter
             exclude: '^(\.github/|GitVersion\.yml)'
           - id: json-sorter
           - id: env-file-check
+          - id: regression-gate
+            stages: [pre-push]


### PR DESCRIPTION
## Summary

- Bump `pre-commit-tools` rev `v0.1.1-73` → `v0.1.1-76`
- Add `regression-gate` hook (pre-push stage) introduced in `v0.1.1-76`

## Changes

``.pre-commit-config.yaml``: rev bump + regression-gate entry