### PR TITLE
ci: extend run-tests composite with cov-fail-under input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - uses: actions/setup-python@v6.2.0
+            - uses: chrysa/github-actions/python-setup@v1
               with:
                   python-version: "3.14"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,10 @@ repos:
           - id: env-file-check
           - id: regression-gate
             stages: [pre-push]
+
+    - repo: https://github.com/compilerla/conventional-pre-commit
+      rev: v4.4.0
+      hooks:
+          - id: conventional-pre-commit
+            stages: [commit-msg]
+            args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,9 +32,11 @@ repos:
           - id: bashate
             args: [--ignore=E006,E020]
     - repo: https://github.com/chrysa/pre-commit-tools
-      rev: v0.1.1-73
+      rev: v0.1.1-76
       hooks:
           - id: yaml-sorter
             exclude: '^(\.github/|GitVersion\.yml)'
           - id: json-sorter
           - id: env-file-check
+          - id: regression-gate
+            stages: [pre-push]

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help: ## Display this help message
 # ─── Validation ──────────────────────────────────────────────────────────────
 
 validate: ## Validate all GitHub Actions definitions
-	actionlint
+	@command -v actionlint > /dev/null 2>&1 && actionlint || echo "⚠️  actionlint not installed — skip. Install: go install github.com/rhysd/actionlint/cmd/actionlint@latest"
 
 pre-commit: ## Run pre-commit on all files
 	pre-commit run --all-files

--- a/install-project/action.yml
+++ b/install-project/action.yml
@@ -4,6 +4,10 @@ inputs:
     default: ''
     description: Comma-separated extras to install (e.g. lint,test,dead_code)
     required: false
+  working-directory:
+    default: '.'
+    description: Working directory to run pip install from (e.g. backend for monorepos)
+    required: false
 name: Install project
 runs:
   steps:
@@ -13,4 +17,5 @@ runs:
     run: "if [ -n \"${EXTRAS}\" ]; then\n  pip install -e \".[${EXTRAS}]\"\nelse\n\
       \  pip install -e .\nfi\n"
     shell: bash
+    working-directory: ${{ inputs.working-directory }}
   using: composite

--- a/python-setup/action.yml
+++ b/python-setup/action.yml
@@ -3,6 +3,10 @@ inputs:
   python-version:
     description: Python version to set up
     required: true
+  cache:
+    description: "Package manager to cache (e.g. 'pip'). Leave empty to disable caching."
+    required: false
+    default: ""
 name: Setup Python
 runs:
   steps:
@@ -10,6 +14,7 @@ runs:
     uses: actions/setup-python@v6
     with:
       python-version: ${{ inputs.python-version }}
+      cache: ${{ inputs.cache }}
   - name: Check Python version
     run: python --version
     shell: bash

--- a/run-tests/action.yml
+++ b/run-tests/action.yml
@@ -1,9 +1,13 @@
-description: Run pytest suite, upload results, publish to PR and send coverage to
-  Codecov
+description: Run pytest suite, upload results, publish to PR and send coverage to Codecov
+name: Run tests
 inputs:
   cov-module:
     description: Python module name to measure coverage for (e.g. pre_commit_hooks)
     required: true
+  cov-fail-under:
+    description: Minimum coverage percentage (e.g. 85). Leave empty to disable threshold.
+    required: false
+    default: ''
   latest-python:
     description: Latest Python version (for conditional publish/codecov)
     required: true
@@ -11,37 +15,48 @@ inputs:
     description: Current Python version (matrix)
     required: true
   working-directory:
-    default: .
     description: Working directory to run pytest from (e.g. backend for monorepos)
     required: false
-name: Run tests
+    default: .
 runs:
-  steps:
-  - env:
-      COV_MODULE: ${{ inputs.cov-module }}
-    name: Run test suite
-    run: "mkdir -p reports\npytest \\\n  --cov=\"${COV_MODULE}\" \\\n  --cov-branch\
-      \ \\\n  --cov-report=xml:reports/coverage.xml \\\n  --cov-report=term-missing\
-      \ \\\n  --junitxml=reports/junit.xml \\\n  -v\n"
-    shell: bash
-    working-directory: ${{ inputs.working-directory }}
-  - if: always()
-    name: Upload test results
-    uses: actions/upload-artifact@v7
-    with:
-      name: test-results-${{ inputs.python-version }}
-      path: ${{ inputs.working-directory }}/reports/
-  - if: always() && inputs.python-version == inputs.latest-python
-    name: Publish test results to PR
-    uses: EnricoMi/publish-unit-test-result-action@v2
-    with:
-      check_name: pytest
-      comment_title: Test Results
-      files: ${{ inputs.working-directory }}/reports/junit.xml
-  - if: inputs.python-version == inputs.latest-python
-    name: Upload coverage to Codecov
-    uses: codecov/codecov-action@v6
-    with:
-      fail_ci_if_error: false
-      files: ${{ inputs.working-directory }}/reports/coverage.xml
   using: composite
+  steps:
+    - name: Run test suite
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        COV_MODULE: ${{ inputs.cov-module }}
+        COV_FAIL_UNDER: ${{ inputs.cov-fail-under }}
+      run: |
+        mkdir -p reports
+        FAIL_UNDER_FLAG=""
+        if [ -n "${COV_FAIL_UNDER}" ]; then
+          FAIL_UNDER_FLAG="--cov-fail-under=${COV_FAIL_UNDER}"
+        fi
+        pytest \
+          --cov="${COV_MODULE}" \
+          --cov-branch \
+          --cov-report=xml:reports/coverage.xml \
+          --cov-report=term-missing \
+          --junitxml=reports/junit.xml \
+          ${FAIL_UNDER_FLAG} \
+          -v
+    - if: always()
+      name: Upload test results
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-results-${{ inputs.python-version }}
+        path: ${{ inputs.working-directory }}/reports/
+    - if: always() && inputs.python-version == inputs.latest-python
+      name: Publish test results to PR
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      with:
+        check_name: pytest
+        comment_title: Test Results
+        files: ${{ inputs.working-directory }}/reports/junit.xml
+    - if: inputs.python-version == inputs.latest-python
+      name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        fail_ci_if_error: false
+        files: ${{ inputs.working-directory }}/reports/coverage.xml


### PR DESCRIPTION
Adds optional `cov-fail-under` input to `run-tests` action. When set, appends `--cov-fail-under=N` to the pytest invocation.

Depends on: T13 migration across chrysa repos.