### PR TITLE
chore(pre-commit): add missing chrysa hooks from standards audit

### DIFF
--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Run actionlint
-      uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8
+      uses: raven-actions/actionlint@3a24062651993d40fed1019b58ac6fbdfbf276cc
       with:
         matcher: true
 name: Actionlint

--- a/.github/workflows/auto-update-pre-commit.yml
+++ b/.github/workflows/auto-update-pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
         persist-credentials: false
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Setup Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
       with:
         python-version: '3.12'
     - name: Install pre-commit
@@ -21,7 +21,7 @@ jobs:
     - name: Autoupdate hooks
       run: pre-commit autoupdate
     - name: Open PR if changes
-      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+      uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f
       with:
         body: Automated weekly bump of `.pre-commit-config.yaml` hooks.
         branch: chore/pre-commit-autoupdate

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ jobs:
         persist-credentials: false
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213
+      uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b
       with:
         sync-labels: true
 name: Pull Request Labels


### PR DESCRIPTION
Part of ecosystem-wide standards audit. Adds missing chrysa/pre-commit-tools hooks based on repo stack detection.

Related: chrysa/pre-commit-tools#168 chrysa/pre-commit-tools#169 chrysa/pre-commit-tools#170 chrysa/pre-commit-tools#171 chrysa/pre-commit-tools#172 chrysa/pre-commit-tools#173