### PR TITLE
fix(pre-commit): apply yaml-sorter formatting to action files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,4 +57,3 @@ updates:
       schedule:
           interval: cron
           cronjob: "0 4 * * 5"
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,4 +48,3 @@ repos:
           - id: conventional-pre-commit
             stages: [commit-msg]
             args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]
-

--- a/python-setup/action.yml
+++ b/python-setup/action.yml
@@ -1,20 +1,20 @@
 description: Set up Python, print version and upgrade pip
 inputs:
+  cache:
+    default: ''
+    description: Package manager to cache (e.g. 'pip'). Leave empty to disable caching.
+    required: false
   python-version:
     description: Python version to set up
     required: true
-  cache:
-    description: "Package manager to cache (e.g. 'pip'). Leave empty to disable caching."
-    required: false
-    default: ""
 name: Setup Python
 runs:
   steps:
   - name: Set up Python ${{ inputs.python-version }}
     uses: actions/setup-python@v6
     with:
-      python-version: ${{ inputs.python-version }}
       cache: ${{ inputs.cache }}
+      python-version: ${{ inputs.python-version }}
   - name: Check Python version
     run: python --version
     shell: bash

--- a/run-tests/action.yml
+++ b/run-tests/action.yml
@@ -1,13 +1,13 @@
-description: Run pytest suite, upload results, publish to PR and send coverage to Codecov
-name: Run tests
+description: Run pytest suite, upload results, publish to PR and send coverage to
+  Codecov
 inputs:
+  cov-fail-under:
+    default: ''
+    description: Minimum coverage percentage (e.g. 85). Leave empty to disable threshold.
+    required: false
   cov-module:
     description: Python module name to measure coverage for (e.g. pre_commit_hooks)
     required: true
-  cov-fail-under:
-    description: Minimum coverage percentage (e.g. 85). Leave empty to disable threshold.
-    required: false
-    default: ''
   latest-python:
     description: Latest Python version (for conditional publish/codecov)
     required: true
@@ -15,48 +15,40 @@ inputs:
     description: Current Python version (matrix)
     required: true
   working-directory:
+    default: .
     description: Working directory to run pytest from (e.g. backend for monorepos)
     required: false
-    default: .
+name: Run tests
 runs:
-  using: composite
   steps:
-    - name: Run test suite
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      env:
-        COV_MODULE: ${{ inputs.cov-module }}
-        COV_FAIL_UNDER: ${{ inputs.cov-fail-under }}
-      run: |
-        mkdir -p reports
-        FAIL_UNDER_FLAG=""
-        if [ -n "${COV_FAIL_UNDER}" ]; then
-          FAIL_UNDER_FLAG="--cov-fail-under=${COV_FAIL_UNDER}"
-        fi
-        pytest \
-          --cov="${COV_MODULE}" \
-          --cov-branch \
-          --cov-report=xml:reports/coverage.xml \
-          --cov-report=term-missing \
-          --junitxml=reports/junit.xml \
-          ${FAIL_UNDER_FLAG} \
-          -v
-    - if: always()
-      name: Upload test results
-      uses: actions/upload-artifact@v7
-      with:
-        name: test-results-${{ inputs.python-version }}
-        path: ${{ inputs.working-directory }}/reports/
-    - if: always() && inputs.python-version == inputs.latest-python
-      name: Publish test results to PR
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      with:
-        check_name: pytest
-        comment_title: Test Results
-        files: ${{ inputs.working-directory }}/reports/junit.xml
-    - if: inputs.python-version == inputs.latest-python
-      name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v6
-      with:
-        fail_ci_if_error: false
-        files: ${{ inputs.working-directory }}/reports/coverage.xml
+  - env:
+      COV_FAIL_UNDER: ${{ inputs.cov-fail-under }}
+      COV_MODULE: ${{ inputs.cov-module }}
+    name: Run test suite
+    run: "mkdir -p reports\nFAIL_UNDER_FLAG=\"\"\nif [ -n \"${COV_FAIL_UNDER}\" ];\
+      \ then\n  FAIL_UNDER_FLAG=\"--cov-fail-under=${COV_FAIL_UNDER}\"\nfi\npytest\
+      \ \\\n  --cov=\"${COV_MODULE}\" \\\n  --cov-branch \\\n  --cov-report=xml:reports/coverage.xml\
+      \ \\\n  --cov-report=term-missing \\\n  --junitxml=reports/junit.xml \\\n  ${FAIL_UNDER_FLAG}\
+      \ \\\n  -v\n"
+    shell: bash
+    working-directory: ${{ inputs.working-directory }}
+  - if: always()
+    name: Upload test results
+    uses: actions/upload-artifact@v7
+    with:
+      name: test-results-${{ inputs.python-version }}
+      path: ${{ inputs.working-directory }}/reports/
+  - if: always() && inputs.python-version == inputs.latest-python
+    name: Publish test results to PR
+    uses: EnricoMi/publish-unit-test-result-action@v2
+    with:
+      check_name: pytest
+      comment_title: Test Results
+      files: ${{ inputs.working-directory }}/reports/junit.xml
+  - if: inputs.python-version == inputs.latest-python
+    name: Upload coverage to Codecov
+    uses: codecov/codecov-action@v6
+    with:
+      fail_ci_if_error: false
+      files: ${{ inputs.working-directory }}/reports/coverage.xml
+  using: composite


### PR DESCRIPTION
Sort YAML keys alphabetically in python-setup/action.yml and run-tests/action.yml. Remove trailing blank lines from dependabot.yml and .pre-commit-config.yaml.

Fixes pre-commit CI failure caused by yaml-sorter detecting unsorted keys.