### PR TITLE
fix(ci): implement dependabot-auto-merge as reusable workflow_call

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,13 +2,37 @@
 name: Dependabot Auto-merge
 
 on:
-    pull_request_target:
-        types: [opened, synchronize, reopened]
+    workflow_call:
 
-concurrency:
-    cancel-in-progress: false
-    group: ${{ github.workflow }}-${{ github.ref }}
+permissions:
+    contents: write
+    pull-requests: write
 
 jobs:
-    call:
-        uses: chrysa/github-actions/.github/workflows/dependabot-auto-merge.yml@main
+    auto-merge:
+        runs-on: ubuntu-latest
+        if: github.actor == 'dependabot[bot]'
+        steps:
+            - name: Fetch Dependabot metadata
+              id: dependabot-metadata
+              uses: dependabot/fetch-metadata@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Enable auto-merge for Dependabot PRs
+              if: >
+                  steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' ||
+                  steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'
+              run: gh pr merge --auto --squash "$PR_URL"
+              env:
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Approve Dependabot PRs
+              if: >
+                  steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' ||
+                  steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'
+              run: gh pr review --approve "$PR_URL"
+              env:
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `dependabot-auto-merge.yml` was calling itself recursively (no `workflow_call:` trigger), causing all 40+ repos that use it to fail with 'workflow file issue'.\n\nThis PR adds the actual implementation:\n- Responds to `workflow_call:` trigger\n- Fetches Dependabot metadata to check update type\n- Auto-merges and approves patch/minor updates via `gh pr merge --auto`\n\nFixes CI failures in: sport-intelligence-hub and all other repos that call this workflow.