### PR TITLE
fix(secret-scan): grant pull-requests:read for gitleaks PR commit listing

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
     contents: read
+    pull-requests: read
 
 jobs:
     gitleaks:


### PR DESCRIPTION
## Problem
`gitleaks-action@v2` fails on **every PR across all consuming repos** with:

```
GET /repos/chrysa/<repo>/pulls/<n>/commits → 403 "Resource not accessible by integration"
```

The action lists PR commits to scan only the diff. The reusable `secret-scan.yml` declared `permissions: contents: read` only, so the `GITHUB_TOKEN` lacked `pull-requests: read`.

## Fix
Add `pull-requests: read` to the workflow permissions block.

## Impact
Re-greens the **Detect secrets (Gitleaks)** check on ~160 open PRs once consuming repos pick up the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)