### PR TITLE
fix(secret-scan): move permissions to job level (top-level broke reusable startup)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -4,14 +4,13 @@ name: Secret scan
 on:
     workflow_call:
 
-permissions:
-    contents: read
-    pull-requests: read
-
 jobs:
     gitleaks:
         name: Detect secrets (Gitleaks)
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: read
         steps:
             - uses: actions/checkout@v4
               with:


### PR DESCRIPTION
## What
Move `permissions` from the workflow top level to the `gitleaks` job level.

## Why
`#98` added top-level `permissions: pull-requests: read` to this reusable workflow. Every repo that calls it via `uses:` then got **startup_failure** (the run never starts). Caller repos (e.g. guideline-checker) succeeded before #98 and broke immediately after. Declaring the permissions at job level is the canonical pattern for reusable workflows and avoids the caller-subset validation that was failing at queue time. Gitleaks still gets `pull-requests: read` to list PR commits (fixes the original 403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)