### PR TITLE
ci: fix dead label-sync action (marocchino 404 -> crazy-max v6)

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -17,9 +17,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Sync labels
-      uses: marocchino/create-labels@v1.3.0
+      uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0
       with:
-        labels: .github/labels.yml
+        yaml-file: .github/labels.yml
+        skip-delete: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 name: Sync GitHub Labels
 permissions:
   contents: read


### PR DESCRIPTION
Replace `marocchino/create-labels@v1.3.0` (the action repo is a 404 / deleted, so this workflow was dead at runtime) with `crazy-max/ghaction-github-labeler@v6` (SHA-pinned), `skip-delete: true` so it only creates/updates labels from `.github/labels.yml` and never removes in-use labels. Org-wide backfill of the shared sync-labels template.

Verified: `.github/labels.yml` present; block matched the template exactly.

Generated with Claude Code