### PR TITLE
feat: add doc-drift composite action

### DIFF
--- a/doc-drift/action.yml
+++ b/doc-drift/action.yml
@@ -1,0 +1,28 @@
+description: Regenerate code-derived docs and fail if they drift from the committed
+  copy
+inputs:
+  paths:
+    default: docs/
+    description: Space-separated paths the drift check inspects
+    required: false
+  target:
+    default: docs-code
+    description: Make target that regenerates code-derived docs (no live server)
+    required: false
+name: Doc drift check
+runs:
+  steps:
+  - env:
+      DOC_TARGET: ${{ inputs.target }}
+    name: Regenerate code-derived docs
+    run: make "${DOC_TARGET}"
+    shell: bash
+  - env:
+      DOC_PATHS: ${{ inputs.paths }}
+      DOC_TARGET: ${{ inputs.target }}
+    name: Fail on documentation drift
+    run: "if ! git diff --exit-code -- ${DOC_PATHS}; then\n  echo \"::error::Generated\
+      \ docs are stale. Run 'make ${DOC_TARGET}' (or 'make docs') locally and commit\
+      \ the result.\"\n  git --no-pager diff --stat -- ${DOC_PATHS}\n  exit 1\nfi\n"
+    shell: bash
+  using: composite


### PR DESCRIPTION
## Why
Generalizes the doc/screenshot drift check piloted in chrysa/sport-intelligence-hub#80. Lets any repo enforce, in its existing CI job, that committed docs match the code — no copy-pasted shell.

## What
New composite action `doc-drift`:
- Runs `make <target>` (default `docs-code`) to regenerate code-derived docs.
- Fails on `git diff --exit-code -- <paths>` (default `docs/`), emitting a `::error::` with the fix command and a `--stat` of the drift.

Inputs: `target` (default `docs-code`), `paths` (default `docs/`).

## Usage
Slot into a job where the stack/toolchain is available (e.g. right after the e2e step):
```yaml
- uses: chrysa/github-actions/doc-drift@main
  # with:
  #   target: docs-code
  #   paths: docs/
```

## Contract
The consuming repo owns its generators behind a `make docs-code` target (skeleton landing in Forge-Stack-Workshop/base-makefile). This action only enforces the diff.

## Related
- Pilot: chrysa/sport-intelligence-hub#80
- Shared pre-commit hook: chrysa/pre-commit-tools#196

🤖 Generated with [Claude Code](https://claude.com/claude-code)