### PR TITLE
feat(workflows): reusable lint-python workflow for release-gated lint

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,0 +1,42 @@
+---
+name: Lint (pre-commit replay)
+
+on:
+    workflow_call:
+        inputs:
+            python-version:
+                type: string
+                required: false
+                default: "3.14"
+            extras:
+                type: string
+                required: false
+                default: "dev"
+
+permissions:
+    contents: read
+
+jobs:
+    lint:
+        name: Ruff + Mypy (pre-commit)
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        steps:
+            - uses: actions/checkout@v6.0.2
+
+            # tool-setup = python-setup + install-project[extras]; ensures mypy
+            # (language: system) and its stubs/deps are available for the replay.
+            - name: Setup environment
+              uses: ./tool-setup
+              with:
+                  python-version: ${{ inputs.python-version }}
+                  extras: ${{ inputs.extras }}
+
+            # Replay every pre-commit hook, including pre-push-staged ones (mypy).
+            # Hooks without an explicit `stages:` (ruff, ruff-format) run at all
+            # stages, so a single invocation covers the full lint surface.
+            - uses: pre-commit/action@v3.0.1
+              with:
+                  extra_args: --all-files --hook-stage pre-push
+              env:
+                  SKIP: no-commit-to-branch

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -15,3 +15,23 @@ This project follows all conventions defined in `CODE_MANIFEST.md` (chrysa portf
 No active deviation is in effect. Any future deviation must be added as a new ADR entry below.
 
 ---
+
+## D-0002 — Release-gated lint via reusable workflow
+
+**Date**: 2026-06-06
+**Status**: accepted
+
+Lint (ruff, ruff-format, mypy) previously ran on every branch push and PR across
+~46 repos, driving high GitHub Actions billing. Lint now lives in pre-commit
+(local, source of truth) and is replayed in CI **only at release time**.
+
+`.github/workflows/lint-python.yml` is a `workflow_call` reusable workflow that
+replays the full pre-commit suite (`pre-commit run --all-files --hook-stage
+pre-push`, which covers ruff at all stages + mypy at the pre-push stage). Consumer
+repos call it as a gate job at the top of their `release.yml` (`version: needs:
+lint`). CI on PR/push keeps only tests + sonar.
+
+Trade-off: PRs are no longer lint-gated in CI; correctness relies on local
+pre-commit hooks, with the release gate as the final safety net.
+
+---


### PR DESCRIPTION
## Why
Lint (ruff + mypy + pre-commit replay) currently runs on **every branch push and PR** across ~46 repos -> high GitHub Actions billing.

## What
Adds `.github/workflows/lint-python.yml` -- a `workflow_call` reusable workflow that replays the full pre-commit suite in one job (`pre-commit run --all-files --hook-stage pre-push` -> ruff/ruff-format at all stages + mypy at pre-push stage). Uses local `./tool-setup` so mypy (language: system) has its deps/stubs.

## Rollout
Consumer repos call this as a **gate job at the top of `release.yml`** (`version: needs: lint`) and drop the `lint`/`pre-commit` jobs from `ci.yml`. Lint runs **once per release** instead of per push. Tests + sonar keep gating PRs. Documented as ADR D-0002.

Pilot consumer: `django-pytest` (separate PR).

Generated with Claude Code