### PR TITLE
fix(sonar-scan-python): skip sonar.tests for non-existent test dirs

### DIFF
--- a/sonar-scan-python/action.yml
+++ b/sonar-scan-python/action.yml
@@ -1,5 +1,5 @@
-description: Download Python analysis reports and run SonarCloud scan with Python-specific
-  configuration
+name: SonarCloud scan (Python)
+description: Download Python analysis reports and run SonarCloud scan with Python-specific configuration
 inputs:
   coverage-report:
     default: reports/coverage.xml
@@ -41,10 +41,10 @@ inputs:
     required: false
   tests:
     default: tests
-    description: Comma-separated test directories (e.g. tests,test)
+    description: Comma-separated test directories (e.g. tests,test). Directories that do not exist are skipped, so sonar.tests is omitted entirely when none are present.
     required: false
-name: SonarCloud scan (Python)
 runs:
+  using: composite
   steps:
   - continue-on-error: true
     name: Download test results (${{ inputs.python-version }})
@@ -67,6 +67,28 @@ runs:
   - name: List reports available for SonarCloud
     run: ls -lh reports/ || echo "reports/ directory is empty or missing"
     shell: bash
+  - name: Resolve existing test directories
+    id: sonar-tests
+    shell: bash
+    env:
+      SONAR_TESTS_INPUT: ${{ inputs.tests }}
+    run: |
+      arg=""
+      existing=()
+      IFS=',' read -ra dirs <<< "$SONAR_TESTS_INPUT"
+      for d in "${dirs[@]}"; do
+        trimmed="$(echo "$d" | xargs)"
+        if [ -n "$trimmed" ] && [ -d "$trimmed" ]; then
+          existing+=("$trimmed")
+        fi
+      done
+      if [ "${#existing[@]}" -gt 0 ]; then
+        joined="$(IFS=','; echo "${existing[*]}")"
+        arg="-Dsonar.tests=$joined"
+      else
+        echo "No configured test directories exist (input: '$SONAR_TESTS_INPUT'); omitting -Dsonar.tests"
+      fi
+      echo "arg=$arg" >> "$GITHUB_OUTPUT"
   - env:
       GITHUB_TOKEN: ${{ inputs.github-token }}
       SONAR_TOKEN: ${{ inputs.sonar-token }}
@@ -79,11 +101,10 @@ runs:
         -Dsonar.projectName=${{ inputs.project-name }}
         -Dsonar.sourceEncoding=UTF-8
         -Dsonar.sources=${{ inputs.sources }}
-        -Dsonar.tests=${{ inputs.tests }}
+        ${{ steps.sonar-tests.outputs.arg }}
         -Dsonar.python.version=${{ inputs.python-version }}
         -Dsonar.python.coverage.reportPaths=${{ inputs.coverage-report }}
         -Dsonar.python.ruff.reportPaths=${{ inputs.ruff-report }}
         -Dsonar.python.mypy.reportPaths=${{ inputs.mypy-report }}
         -Dsonar.python.xunit.reportPath=${{ inputs.junit-report }}
         -Dsonar.exclusions=**/__pycache__/**,**/*.egg-info/**,**/.git/**,**/node_modules/**
-  using: composite

--- a/sonar-scan-python/action.yml
+++ b/sonar-scan-python/action.yml
@@ -41,7 +41,7 @@ inputs:
     required: false
   tests:
     default: tests
-    description: Comma-separated test directories (e.g. tests,test). Directories that do not exist are skipped, so sonar.tests is omitted entirely when none are present.
+    description: Comma-separated test directories (e.g. tests,test). Directories that do not exist are skipped (sonar.tests omitted entirely when none are present). Existing test dirs are also added to sonar.exclusions so a broad sonar.sources (e.g. ".") does not index them twice.
     required: false
 runs:
   using: composite
@@ -67,13 +67,14 @@ runs:
   - name: List reports available for SonarCloud
     run: ls -lh reports/ || echo "reports/ directory is empty or missing"
     shell: bash
-  - name: Resolve existing test directories
+  - name: Resolve test directories and Sonar exclusions
     id: sonar-tests
     shell: bash
     env:
       SONAR_TESTS_INPUT: ${{ inputs.tests }}
     run: |
-      arg=""
+      base='**/__pycache__/**,**/*.egg-info/**,**/.git/**,**/node_modules/**'
+      tests_arg=""
       existing=()
       IFS=',' read -ra dirs <<< "$SONAR_TESTS_INPUT"
       for d in "${dirs[@]}"; do
@@ -82,13 +83,19 @@ runs:
           existing+=("$trimmed")
         fi
       done
+      excl="$base"
       if [ "${#existing[@]}" -gt 0 ]; then
         joined="$(IFS=','; echo "${existing[*]}")"
-        arg="-Dsonar.tests=$joined"
+        tests_arg="-Dsonar.tests=$joined"
+        # Keep test dirs out of the main source set so sonar.sources="." does not index them twice.
+        for d in "${existing[@]}"; do
+          excl="$excl,$d/**"
+        done
       else
         echo "No configured test directories exist (input: '$SONAR_TESTS_INPUT'); omitting -Dsonar.tests"
       fi
-      echo "arg=$arg" >> "$GITHUB_OUTPUT"
+      echo "tests_arg=$tests_arg" >> "$GITHUB_OUTPUT"
+      echo "exclusions=$excl" >> "$GITHUB_OUTPUT"
   - env:
       GITHUB_TOKEN: ${{ inputs.github-token }}
       SONAR_TOKEN: ${{ inputs.sonar-token }}
@@ -101,10 +108,10 @@ runs:
         -Dsonar.projectName=${{ inputs.project-name }}
         -Dsonar.sourceEncoding=UTF-8
         -Dsonar.sources=${{ inputs.sources }}
-        ${{ steps.sonar-tests.outputs.arg }}
+        ${{ steps.sonar-tests.outputs.tests_arg }}
         -Dsonar.python.version=${{ inputs.python-version }}
         -Dsonar.python.coverage.reportPaths=${{ inputs.coverage-report }}
         -Dsonar.python.ruff.reportPaths=${{ inputs.ruff-report }}
         -Dsonar.python.mypy.reportPaths=${{ inputs.mypy-report }}
         -Dsonar.python.xunit.reportPath=${{ inputs.junit-report }}
-        -Dsonar.exclusions=**/__pycache__/**,**/*.egg-info/**,**/.git/**,**/node_modules/**
+        -Dsonar.exclusions=${{ steps.sonar-tests.outputs.exclusions }}


### PR DESCRIPTION
## Problem

`sonar-scan-python` always passes `-Dsonar.tests=${{ inputs.tests }}` (input defaults to `tests`). Any consumer repo without a `tests/` directory fails the SonarCloud scan:

```
ERROR Invalid value of sonar.tests for chrysa_<repo>
ERROR The folder 'tests' does not exist ... (base directory = ...)
INFO  EXECUTION FAILURE
##[error]Process completed with exit code 3.
```

This currently blocks every PR in `chrysa/shared-standards` (no `tests/` dir).

## Fix

Add a `Resolve existing test directories` step that keeps only the configured test dirs that actually exist, then injects `-Dsonar.tests=<existing>` into the scanner args — or omits the flag entirely when none exist. Repos that *do* have tests are unaffected.

## Follow-up

After merge, cut a release (e.g. `v1.1.1`) and repoint consumers pinned to `@v1.1.0` (e.g. `chrysa/shared-standards` `.github/workflows/sonar.yml`).

Found by automated PR triage while processing open chrysa PRs.

---

### Update — second failure mode covered

Diagnosis of the wider rollout batch showed a second Sonar failure: repos that **do** have a `tests/` dir under `sonar.sources="."` failed with `File tests/... can't be indexed twice`. The action now also appends existing test dirs to `sonar.exclusions`, so the main source set and test set are disjoint. Both failure modes (missing dir, and overlap) are fixed in one place.
