### PR TITLE
chore(makefile): declare makefile-tier (lib)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# makefile-tier: lib
 #!make
 ifneq (,)
 	$(error This Makefile requires GNU Make)


### PR DESCRIPTION
Adds the `# makefile-tier: lib` marker required by the chrysa Makefile contract (shared-standards EXECUTION_STANDARD.md §1, PR #87) and enforced by the `makefile-check` hook (pre-commit-tools PR #200). No target changes — this repo already conforms to the `lib` tier.

Part of the Makefile uniformization campaign (Phase C, wave 1: marker-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)