### PR TITLE
fix(lint-python): resolve tool-setup via fully-qualified path

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -27,7 +27,7 @@ jobs:
             # tool-setup = python-setup + install-project[extras]; ensures mypy
             # (language: system) and its stubs/deps are available for the replay.
             - name: Setup environment
-              uses: ./tool-setup
+              uses: chrysa/github-actions/tool-setup@v1.0.12
               with:
                   python-version: ${{ inputs.python-version }}
                   extras: ${{ inputs.extras }}


### PR DESCRIPTION
## Problem
`lint-python.yml` (reusable lint gate) referenced the tool-setup composite as `./tool-setup`. As a reusable workflow called from a consumer repo, `./` resolves to the **caller's** checkout — which has no `tool-setup/` action. The lint gate would fail at "Setup environment" before ruff/mypy ran. Never surfaced because Actions are billing-blocked (no runs since 2026-06-05).

## Fix
Reference `chrysa/github-actions/tool-setup@v1.0.12` (fully qualified) so it always resolves to this repo's composite.

## Impact
Unblocks the release-gated lint pattern for all consumers (django-pytest, django-traceid pilots + the ~30-repo batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
