### PR TITLE
feat(deploy): add frontend-target input

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,15 @@ on:
                 required: false
                 default: Dockerfile
             target:
-                description: Dockerfile target stage to build
+                description: Dockerfile target stage to build (backend; also frontend unless frontend-target is set)
                 type: string
                 required: false
                 default: production
+            frontend-target:
+                description: Dockerfile target for the frontend image (defaults to `target` when empty)
+                type: string
+                required: false
+                default: ''
             build-frontend:
                 description: Also build + push a frontend image
                 type: boolean
@@ -183,7 +188,7 @@ jobs:
               with:
                   context: ${{ inputs.frontend-context }}
                   file: ${{ inputs.frontend-dockerfile }}
-                  target: ${{ inputs.target }}
+                  target: ${{ inputs.frontend-target || inputs.target }}
                   build-args: ${{ inputs.frontend-build-args }}
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Lets callers build the frontend from a different Dockerfile target than the backend (e.g. doc-gen: backend `api`, frontend `production`). Falls back to `target` when empty — existing callers unaffected. actionlint clean.