### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,56 +1,88 @@
----
 default_language_version:
   python: python3.14
 fail_fast: false
 minimum_pre_commit_version: 4.1.0
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: fa6b006f0e53d6c0a4a30d6f7b1200a899444634
-      hooks:
-          - id: check-json
-          - id: check-yaml
-            exclude: ^\.github/ISSUE_TEMPLATE/
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
-          - id: detect-private-key
-          - id: no-commit-to-branch
-            args: [--branch, main]
-    - repo: https://github.com/igorshubovych/markdownlint-cli
-      rev: a4d5d37e66ebcd6b3705204a1d6dbb56dea66338
-      hooks:
-          - id: markdownlint
-            args: [--fix]
-            stages: [manual]
-    - repo: https://github.com/lovesegfault/beautysh
-      rev: 34c3b3da0233e76d7d1ad90a78f3679185ecf31c
-      hooks:
-          - id: beautysh
-            args: [--indent-size, '4']
-    - repo: https://github.com/openstack/bashate
-      rev: ec2f2400915200d633299612a02d7d285e4be24c
-      hooks:
-          - id: bashate
-            args: [--ignore=E006, E020]
-    - repo: https://github.com/chrysa/pre-commit-tools
-      rev: v0.1.1-94
-      hooks:
-          - id: makefile-check
-          - id: yaml-sorter
-            exclude: '^(\.github/|GitVersion\.yml)'
-          - id: json-sorter
-          - id: env-file-check
-          - id: adr-gate
-          - id: regression-gate
-            stages: [pre-push]
-          - id: env-example-sync
-
-    - repo: https://github.com/compilerla/conventional-pre-commit
-      rev: v4.4.0
-      hooks:
-          - id: conventional-pre-commit
-            stages: [commit-msg]
-            args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]
-    - repo: https://github.com/gitleaks/gitleaks
-      rev: v8.30.1
-      hooks:
-          - id: gitleaks
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: fa6b006f0e53d6c0a4a30d6f7b1200a899444634
+  hooks:
+  - id: check-json
+  - id: check-yaml
+    exclude: ^\.github/ISSUE_TEMPLATE/
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: detect-private-key
+  - id: no-commit-to-branch
+    args:
+    - --branch
+    - main
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: a4d5d37e66ebcd6b3705204a1d6dbb56dea66338
+  hooks:
+  - id: markdownlint
+    args:
+    - --fix
+    stages:
+    - manual
+- repo: https://github.com/lovesegfault/beautysh
+  rev: 34c3b3da0233e76d7d1ad90a78f3679185ecf31c
+  hooks:
+  - id: beautysh
+    args:
+    - --indent-size
+    - '4'
+- repo: https://github.com/openstack/bashate
+  rev: ec2f2400915200d633299612a02d7d285e4be24c
+  hooks:
+  - id: bashate
+    args:
+    - --ignore=E006
+    - E020
+- repo: https://github.com/chrysa/pre-commit-tools
+  rev: v0.1.1-94
+  hooks:
+  - id: makefile-check
+  - id: yaml-sorter
+    exclude: ^(\.github/|GitVersion\.yml)
+  - id: json-sorter
+  - id: env-file-check
+  - id: adr-gate
+  - id: regression-gate
+    stages:
+    - pre-push
+  - id: env-example-sync
+- repo: https://github.com/compilerla/conventional-pre-commit
+  rev: v4.4.0
+  hooks:
+  - id: conventional-pre-commit
+    stages:
+    - commit-msg
+    args:
+    - feat
+    - fix
+    - docs
+    - style
+    - refactor
+    - test
+    - chore
+    - perf
+    - revert
+    - ci
+- repo: https://github.com/gitleaks/gitleaks
+  rev: v8.30.1
+  hooks:
+  - id: gitleaks
+- repo: local
+  hooks:
+  - id: gitversion-canonical-drift
+    name: GitVersion.yml canonical drift
+    entry: scripts/check-canonical-drift.sh GitVersion.yml templates/GitVersion.yml
+    language: system
+    pass_filenames: false
+    files: ^(GitVersion\.yml|templates/GitVersion\.yml)$
+  - id: cliff-canonical-drift
+    name: cliff.toml canonical drift
+    entry: scripts/check-canonical-drift.sh cliff.toml templates/cliff.toml
+    language: system
+    pass_filenames: false
+    files: ^(cliff\.toml|templates/cliff\.toml)$


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@5292b616e3723f95d2764649fe7b31429497d7ed`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards