### PR TITLE
fix(actions): self-install lint tools when absent (kill exit-127 reds)

### DIFF
--- a/mypy-check/action.yml
+++ b/mypy-check/action.yml
@@ -16,17 +16,31 @@ inputs:
 name: Mypy check
 runs:
   steps:
+  - name: "mypy — ensure available"
+    run: 'if ! command -v mypy >/dev/null 2>&1; then
+
+      echo "::warning::mypy not found on PATH; installing a fallback. Declare mypy
+      in your project''s [lint] extra to pin a version."
+
+      python -m pip install mypy
+
+      fi
+
+      mypy --version
+
+      '
+    shell: bash
   - env:
       MYPY_CONFIG: ${{ inputs.config-file }}
       MYPY_SOURCES: ${{ inputs.sources }}
-    name: "mypy \u2014 type check"
+    name: "mypy — type check"
     run: mypy --config-file="${MYPY_CONFIG}" ${MYPY_SOURCES}
     shell: bash
   - env:
       MYPY_CONFIG: ${{ inputs.config-file }}
       MYPY_SOURCES: ${{ inputs.sources }}
     if: always() && inputs.python-version == inputs.latest-python
-    name: "mypy \u2014 produce text report"
+    name: "mypy — produce text report"
     run: 'mkdir -p reports
 
       mypy --config-file="${MYPY_CONFIG}" --no-error-summary ${MYPY_SOURCES} > reports/mypy.txt

--- a/ruff-check/action.yml
+++ b/ruff-check/action.yml
@@ -20,17 +20,32 @@ inputs:
 name: Ruff check
 runs:
   steps:
+  - name: "ruff — ensure available"
+    run: 'if ! command -v ruff >/dev/null 2>&1; then
+
+      echo "::warning::ruff not found on PATH; installing a fallback. Declare ruff
+      in your project''s [lint] extra to pin a version."
+
+      python -m pip install ruff
+
+      fi
+
+      ruff --version
+
+      '
+    shell: bash
+    working-directory: ${{ inputs.working-directory }}
   - env:
       RUFF_CONFIG: ${{ inputs.config }}
       RUFF_SOURCES: ${{ inputs.sources }}
-    name: "ruff \u2014 lint check"
+    name: "ruff — lint check"
     run: ruff check --config="${RUFF_CONFIG}" ${RUFF_SOURCES}
     shell: bash
     working-directory: ${{ inputs.working-directory }}
   - env:
       RUFF_CONFIG: ${{ inputs.config }}
       RUFF_SOURCES: ${{ inputs.sources }}
-    name: "ruff \u2014 format check"
+    name: "ruff — format check"
     run: ruff format --check --config="${RUFF_CONFIG}" ${RUFF_SOURCES}
     shell: bash
     working-directory: ${{ inputs.working-directory }}
@@ -38,7 +53,7 @@ runs:
       RUFF_CONFIG: ${{ inputs.config }}
       RUFF_SOURCES: ${{ inputs.sources }}
     if: always() && inputs.python-version == inputs.latest-python
-    name: "ruff \u2014 produce JSON report"
+    name: "ruff — produce JSON report"
     run: 'mkdir -p reports
 
       ruff check --config="${RUFF_CONFIG}" --output-format=json ${RUFF_SOURCES} >


### PR DESCRIPTION
## Context

`ruff-check` and `mypy-check` composite actions invoke the tool directly and rely on the consuming repo having installed it via `tool-setup` → `install-project` (`pip install -e ".[lint]"`). When a repo's `pyproject.toml` omits the tool from its `lint` extra (or passes no `extras`), the step fails with `command not found` (exit 127) — an **infra failure that masks the real lint result** fleet-wide. The "Lint reports for Sonar" job goes red without any actual lint signal.

## Change

Prepend a guard step to each action that installs the tool **only if it is not already on PATH** (`command -v ... || python -m pip install ...`), then prints the version.

- Repos that already install the tool via their `lint` extra: the check succeeds → install skipped → **byte-for-byte identical behavior** (still pinned to the repo's version).
- Repos currently dying at exit 127: the tool installs, real lint runs (pass or surfaces genuine violations) instead of an opaque infra error.
- A `::warning::` nudges those repos to pin the tool in their `[lint]` extra.

`python` is already provisioned by `python-setup` (run via `tool-setup` before these actions), so `python -m pip install` is safe.

## Verification

- YAML validated (`yaml.safe_load`) for both files.
- After merge + tag bump, the consuming `ci-python.yml` "Lint reports for Sonar" job should no longer exit 127 in repos lacking a `lint` extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
