### PR TITLE
fix(pre-commit): drop leaked canonical-drift local hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,17 +72,3 @@ repos:
   rev: v8.30.1
   hooks:
   - id: gitleaks
-- repo: local
-  hooks:
-  - id: gitversion-canonical-drift
-    name: GitVersion.yml canonical drift
-    entry: scripts/check-canonical-drift.sh GitVersion.yml templates/GitVersion.yml
-    language: system
-    pass_filenames: false
-    files: ^(GitVersion\.yml|templates/GitVersion\.yml)$
-  - id: cliff-canonical-drift
-    name: cliff.toml canonical drift
-    entry: scripts/check-canonical-drift.sh cliff.toml templates/cliff.toml
-    language: system
-    pass_filenames: false
-    files: ^(cliff\.toml|templates/cliff\.toml)$


### PR DESCRIPTION
## Context

This repo's `.pre-commit-config.yaml` carries two `repo: local` hooks —
`gitversion-canonical-drift` and `cliff-canonical-drift` — that leaked from the shared
baseline. They run `scripts/check-canonical-drift.sh` against `templates/` copies that exist
**only in shared-standards**, so here every pre-commit run fails with
`Executable scripts/check-canonical-drift.sh not found`, reddening the `Pre-commit`/`Lint` CI job.

## Change

Remove the leaked `canonical-drift` hooks (and the now-empty `repo: local` block where applicable).
No other hooks touched.

Source fix that prevents re-leak on the next baseline sync: chrysa/shared-standards#131
(`pre-commit-merge.py` no longer distributes `repo: local` hooks).

## Verification

`pre-commit run --all-files` passes after removal (verified on django-query-optimizer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
