### PR TITLE
fix(release): tag with majorMinorPatch for clean SemVer tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Generate changelog
               id: changelog
               run: |
-                  CURRENT_TAG="v${{ steps.gitversion.outputs.semVer }}"
+                  CURRENT_TAG="v${{ steps.gitversion.outputs.majorMinorPatch }}"
                   git cliff --output CHANGELOG_RELEASE.md --tag "$CURRENT_TAG" 2>/dev/null || \
                     git cliff --unreleased --output CHANGELOG_RELEASE.md
                   echo "version=$CURRENT_TAG" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The reusable `release.yml` tags releases with `steps.gitversion.outputs.semVer`. On an untagged main commit, GitVersion's `semVer` appends `CommitsSinceVersionSource` as a **pre-release suffix** — so consumers get ugly tags like `v1.0.0-148`, `v1.0.0-149` (one per push) instead of a clean `v1.0.0`.

Discovered while fixing `chrysa/guideline-checker`'s release pipeline: after resolving two startup-failure causes (`secrets: inherit` + `permissions: contents: write`), the pipeline finally cut a tag — but it was `v1.0.0-149`, and no per-repo GitVersion config can remove the suffix because the field is chosen here, in the shared reusable.

## Fix

Tag with `majorMinorPatch` (`1.0.0`) instead of `semVer`. Effects:
- Released tag is clean SemVer: `v1.0.0`.
- A new tag is cut only when the **computed version actually changes** (a bump-message commit), not on every push. The existing `git tag ... || echo "Tag already exists"` already makes re-runs idempotent.
- Changelog + release name use the same clean tag.

## Fleet impact

Every chrysa repo consuming this reusable switches from `-NNN` pre-release tags to clean SemVer tags. This is the intended behavior; no consumer action required beyond bumping the pinned ref to the new release tag.