### PR TITLE
fix(release): floor next-version to 1.2.2 to unstick self-versioning

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -19,6 +19,10 @@ branches:
     mode: ContinuousDelivery
     regex: ^main$
     tag: ''
+# One-time floor to unstick self-versioning: the v1.2.1 tag was cut on an
+# off-mainline commit, so GitVersion keeps recomputing 1.2.1 (already taken)
+# and never advances. Floor to 1.2.2 to cut the next mainline tag cleanly.
+next-version: 1.2.2
 increment: Inherit
 major-version-bump-message: ^(feat|fix|refactor)(\(.+\))?!:.+
 minor-version-bump-message: ^feat(\(.+\))?:.+


### PR DESCRIPTION
## Problem

github-actions' self-tag job (`ci.yml` → `Tag release`) computes `MajorMinorPatch` and skips if that tag exists. It's stuck: `v1.2.1` was tagged on an **off-mainline** commit (`b0050819`, not an ancestor of main), so GitVersion ignores it and keeps computing `1.2.1` from the `v1.2.0`/`v1` source — which already exists → no new tag is ever cut. Consequence: the `majorMinorPatch` tagging fix (#140) sits on main with no release tag carrying it, forcing consumers to SHA-pin.

## Fix

Add a one-time `next-version: 1.2.2` floor. GitVersion takes `max(computed, floor)` = `1.2.2`, which doesn't exist → the next push to main cuts a clean **v1.2.2** on mainline. From there GitVersion sources off `v1.2.2` and self-advances; the off-mainline `v1.2.1` becomes irrelevant.

After merge: `v1.2.2` is cut → re-pin `chrysa/guideline-checker` release caller from the `@f4b936d` SHA to `@v1.2.2`.