### PR TITLE
fix: resolve SonarCloud blocker & critical findings

### DIFF
--- a/.github/workflows/ci-fullstack.yml
+++ b/.github/workflows/ci-fullstack.yml
@@ -104,7 +104,9 @@ jobs:
               with:
                   node-version: ${{ inputs.node-version }}
             - name: Run test suite
-              run: make ${{ inputs.test-target }}
+              env:
+                  TEST_TARGET: ${{ inputs.test-target }}
+              run: make "$TEST_TARGET"
               shell: bash
             - name: Collect coverage reports
               if: always()

--- a/.github/workflows/ci-python-app.yml
+++ b/.github/workflows/ci-python-app.yml
@@ -125,9 +125,12 @@ jobs:
                   sources: ${{ inputs.sources }}
 
             - name: Mypy report
+              env:
+                  TYPECHECK_PATHS: ${{ inputs.typecheck-paths }}
               run: |
                   mkdir -p reports
-                  mypy --config-file=pyproject.toml ${{ inputs.typecheck-paths }} \
+                  # shellcheck disable=SC2086 # paths may be space-separated; word-splitting is intended
+                  mypy --config-file=pyproject.toml ${TYPECHECK_PATHS} \
                       | tee reports/mypy.txt || true
               shell: bash
 

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -142,9 +142,12 @@ jobs:
                   sources: ${{ inputs.sources }}
 
             - name: Mypy report
+              env:
+                  TYPECHECK_PATHS: ${{ inputs.typecheck-paths }}
               run: |
                   mkdir -p reports
-                  mypy --config-file=pyproject.toml ${{ inputs.typecheck-paths }} \
+                  # shellcheck disable=SC2086 # paths may be space-separated; word-splitting is intended
+                  mypy --config-file=pyproject.toml ${TYPECHECK_PATHS} \
                       | tee reports/mypy.txt || true
               shell: bash
 


### PR DESCRIPTION
## Summary

Resolves all 3 open SonarCloud **BLOCKER** findings (rule `githubactions:S7630`, script injection) in the reusable workflows. No CRITICAL findings were open.

| File | Line | Input | Fix |
|------|------|-------|-----|
| `ci-fullstack.yml` | 107 | `inputs.test-target` | env `TEST_TARGET`, quoted `make "$TEST_TARGET"` |
| `ci-python-app.yml` | 130 | `inputs.typecheck-paths` | env `TYPECHECK_PATHS`, unquoted (multi-path) |
| `ci-python.yml` | 147 | `inputs.typecheck-paths` | env `TYPECHECK_PATHS`, unquoted (multi-path) |

## Why

Each step interpolated a user-controlled `${{ inputs.* }}` value directly into the `run:` script, letting whoever triggers the workflow inject shell. Routing the value through a step-level `env:` var means GitHub no longer expands it into the script text — the shell receives it as data.

## Behaviour preserved

- `test-target` is a single make target → safely quoted `"$TEST_TARGET"`.
- `typecheck-paths` is documented as space-separated **Path(s)** → kept unquoted (`${TYPECHECK_PATHS}`) to preserve word-splitting, with an explicit `# shellcheck disable=SC2086` note explaining the intent.

## Verification

- `actionlint` via Docker (`rhysd/actionlint`, bundles shellcheck) → **exit 0** on all three files.
- YAML re-validated with PyYAML.
- No unit tests in this repo (composite actions + reusable workflows only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)