### PR TITLE
fix(quality-gate): skip verify when 'quality-gate-verify' target is absent

### DIFF
--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -32,7 +32,12 @@ jobs:
           if [ -f package.json ]; then npm ci; fi
       - name: Run quality gate verification
         id: quality-gate
-        run: make quality-gate-verify || exit_code=$?; exit "${exit_code:-0}"
+        run: |
+          if make -n quality-gate-verify >/dev/null 2>&1; then
+            make quality-gate-verify
+          else
+            echo "::notice::No 'quality-gate-verify' target found - skipping quality gate (repo not onboarded)."
+          fi
       - name: Report quality gate status
         if: always()
         run: |


### PR DESCRIPTION
Reusable `No-Regression Quality Gates` ran `make quality-gate-verify`, but repos not onboarded to the quality-gate subsystem lack that target → `No rule to make target` aborted the check across every consuming repo (false negative on trivial dependency bumps).

This guards the call with `make -n`: the gate is **skipped non-fatally** where the target is missing and stays **enforced** where present. No behavior change for onboarded repos.

hotfix — shared CI infra.