### PR TITLE
feat(deploy): add frontend-target input (separate from backend target)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,15 @@ on:
                 required: false
                 default: Dockerfile
             target:
-                description: Dockerfile target stage to build
+                description: Dockerfile target stage to build (backend; also frontend unless frontend-target is set)
                 type: string
                 required: false
                 default: production
+            frontend-target:
+                description: Dockerfile target for the frontend image (defaults to `target` when empty)
+                type: string
+                required: false
+                default: ''
             build-frontend:
                 description: Also build + push a frontend image
                 type: boolean
@@ -183,7 +188,7 @@ jobs:
               with:
                   context: ${{ inputs.frontend-context }}
                   file: ${{ inputs.frontend-dockerfile }}
-                  target: ${{ inputs.target }}
+                  target: ${{ inputs.frontend-target || inputs.target }}
                   build-args: ${{ inputs.frontend-build-args }}
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary
Adds a `frontend-target` input to the reusable `deploy.yml`. Some repos build backend and frontend from different Dockerfile target stages (e.g. doc-gen: backend `api`, frontend `production`). `frontend-target` falls back to `target` when empty, so existing callers are unaffected.

## Verification
- `actionlint .github/workflows/deploy.yml`: clean (only the 2 pre-existing SC2015 info warnings).

Note: `deploy.yml` is also touched by the self-hosted-runner work (#150, runner parametrization) — a small merge alignment is expected depending on merge order.

Generated with Claude Code