### PR TITLE
feat(ci): parametrize reusable-workflow runs-on (chrysa-arc) [recovers #150 workflows]

### DIFF
--- a/.github/workflows/ci-fullstack.yml
+++ b/.github/workflows/ci-fullstack.yml
@@ -74,7 +74,7 @@ concurrency:
 jobs:
     gate:
         name: Pre-commit (lint/format/type/secrets, both stacks)
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 20
         permissions:
             contents: read
@@ -100,7 +100,7 @@ jobs:
 
     test:
         name: Tests (make ${{ inputs.test-target }})
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 30
         permissions:
             contents: read
@@ -139,7 +139,7 @@ jobs:
         name: SonarCloud
         if: ${{ inputs.run-sonar && github.actor != 'dependabot[bot]' }}
         needs: [test, gate]
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 15
         permissions:
             contents: read

--- a/.github/workflows/ci-fullstack.yml
+++ b/.github/workflows/ci-fullstack.yml
@@ -57,6 +57,10 @@ on:
                 type: boolean
                 required: false
                 default: true
+            runner:
+                description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+                type: string
+                default: chrysa-arc
         secrets:
             SONAR_TOKEN:
                 required: false
@@ -70,7 +74,7 @@ concurrency:
 jobs:
     gate:
         name: Pre-commit (lint/format/type/secrets, both stacks)
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 20
         permissions:
             contents: read
@@ -96,7 +100,7 @@ jobs:
 
     test:
         name: Tests (make ${{ inputs.test-target }})
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 30
         permissions:
             contents: read
@@ -135,7 +139,7 @@ jobs:
         name: SonarCloud
         if: ${{ inputs.run-sonar && github.actor != 'dependabot[bot]' }}
         needs: [test, gate]
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 15
         permissions:
             contents: read

--- a/.github/workflows/ci-python-app.yml
+++ b/.github/workflows/ci-python-app.yml
@@ -87,7 +87,7 @@ concurrency:
 jobs:
     lint:
         name: Pre-commit (lint/format/type/secrets/actionlint)
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 15
         permissions:
             contents: read
@@ -108,7 +108,7 @@ jobs:
 
     reports:
         name: Lint reports for Sonar
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 15
         permissions:
             contents: read
@@ -146,7 +146,7 @@ jobs:
 
     test:
         name: Docker tests (compose)
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 25
         permissions:
             contents: read
@@ -179,7 +179,7 @@ jobs:
         name: SonarCloud
         if: ${{ inputs.run-sonar && github.actor != 'dependabot[bot]' }}
         needs: [test, reports]
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 15
         permissions:
             contents: read

--- a/.github/workflows/ci-python-app.yml
+++ b/.github/workflows/ci-python-app.yml
@@ -70,6 +70,10 @@ on:
                 type: boolean
                 required: false
                 default: true
+            runner:
+                description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+                type: string
+                default: chrysa-arc
         secrets:
             SONAR_TOKEN:
                 required: false
@@ -83,7 +87,7 @@ concurrency:
 jobs:
     lint:
         name: Pre-commit (lint/format/type/secrets/actionlint)
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 15
         permissions:
             contents: read
@@ -104,7 +108,7 @@ jobs:
 
     reports:
         name: Lint reports for Sonar
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 15
         permissions:
             contents: read
@@ -142,7 +146,7 @@ jobs:
 
     test:
         name: Docker tests (compose)
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 25
         permissions:
             contents: read
@@ -175,7 +179,7 @@ jobs:
         name: SonarCloud
         if: ${{ inputs.run-sonar && github.actor != 'dependabot[bot]' }}
         needs: [test, reports]
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 15
         permissions:
             contents: read

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -101,7 +101,7 @@ concurrency:
 jobs:
     lint:
         name: Pre-commit (lint/format/type/secrets/actionlint)
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 15
         permissions:
             contents: read
@@ -124,7 +124,7 @@ jobs:
 
     reports:
         name: Lint reports for Sonar
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 15
         permissions:
             contents: read
@@ -163,7 +163,7 @@ jobs:
 
     test:
         name: Tests (py${{ matrix.python-version }})
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 20
         permissions:
             contents: read
@@ -195,7 +195,7 @@ jobs:
         name: SonarCloud
         if: ${{ inputs.run-sonar && github.actor != 'dependabot[bot]' }}
         needs: [test, reports]
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 15
         permissions:
             contents: read

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -84,6 +84,10 @@ on:
                 type: boolean
                 required: false
                 default: true
+            runner:
+                description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+                type: string
+                default: chrysa-arc
         secrets:
             SONAR_TOKEN:
                 required: false
@@ -97,7 +101,7 @@ concurrency:
 jobs:
     lint:
         name: Pre-commit (lint/format/type/secrets/actionlint)
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 15
         permissions:
             contents: read
@@ -120,7 +124,7 @@ jobs:
 
     reports:
         name: Lint reports for Sonar
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 15
         permissions:
             contents: read
@@ -159,7 +163,7 @@ jobs:
 
     test:
         name: Tests (py${{ matrix.python-version }})
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 20
         permissions:
             contents: read
@@ -191,7 +195,7 @@ jobs:
         name: SonarCloud
         if: ${{ inputs.run-sonar && github.actor != 'dependabot[bot]' }}
         needs: [test, reports]
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 15
         permissions:
             contents: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,6 +3,11 @@ name: Dependabot Auto-merge
 
 on:
     workflow_call:
+        inputs:
+            runner:
+                description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+                type: string
+                default: chrysa-arc
 
 permissions:
     contents: write
@@ -10,7 +15,7 @@ permissions:
 
 jobs:
     auto-merge:
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         if: github.actor == 'dependabot[bot]'
         steps:
             - name: Fetch Dependabot metadata

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
     auto-merge:
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         if: github.actor == 'dependabot[bot]'
         steps:
             - name: Fetch Dependabot metadata

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -3,6 +3,11 @@ name: PR Dependency Check
 
 on:
     workflow_call:
+        inputs:
+            runner:
+                description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+                type: string
+                default: chrysa-arc
     pull_request_target:
         types: [closed, edited, opened, reopened]
 
@@ -12,7 +17,7 @@ permissions:
 
 jobs:
     check_dependencies:
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         name: Check PR dependencies
 
         steps:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
     check_dependencies:
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         name: Check PR dependencies
 
         steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,7 @@ concurrency:
 jobs:
     build-backend:
         name: Build & push backend
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@v7.0.0
@@ -163,7 +163,7 @@ jobs:
     build-frontend:
         name: Build & push frontend
         if: ${{ inputs.build-frontend }}
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@v7.0.0
@@ -204,7 +204,7 @@ jobs:
         name: GitOps — bump catalog image tags
         if: ${{ inputs.gitops && always() }}
         needs: [build-backend, build-frontend]
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 10
         steps:
             - name: Guard — backend must have succeeded

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,10 @@ on:
                 type: string
                 required: false
                 default: ''
+            runner:
+                description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+                type: string
+                default: chrysa-arc
         secrets:
             release-token:
                 description: PAT with write access to the catalog repo (gitops only)
@@ -119,7 +123,7 @@ concurrency:
 jobs:
     build-backend:
         name: Build & push backend
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@v7.0.0
@@ -159,7 +163,7 @@ jobs:
     build-frontend:
         name: Build & push frontend
         if: ${{ inputs.build-frontend }}
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@v7.0.0
@@ -200,7 +204,7 @@ jobs:
         name: GitOps — bump catalog image tags
         if: ${{ inputs.gitops && always() }}
         needs: [build-backend, build-frontend]
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 10
         steps:
             - name: Guard — backend must have succeeded

--- a/.github/workflows/enforce-feature-branch.yml
+++ b/.github/workflows/enforce-feature-branch.yml
@@ -3,6 +3,11 @@ name: Enforce Feature Branch Policy
 
 on:
     workflow_call:
+        inputs:
+            runner:
+                description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+                type: string
+                default: chrysa-arc
 
 permissions:
     contents: read
@@ -10,7 +15,7 @@ permissions:
 jobs:
     branch-policy:
         if: github.actor != 'dependabot[bot]'
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         steps:
             - name: Validate PR source branch naming
               shell: bash

--- a/.github/workflows/enforce-feature-branch.yml
+++ b/.github/workflows/enforce-feature-branch.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
     branch-policy:
         if: github.actor != 'dependabot[bot]'
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         steps:
             - name: Validate PR source branch naming
               shell: bash

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,11 +1,16 @@
 "on":
   pull_request: null
-  workflow_call: null
+  workflow_call:
+    inputs:
+      runner:
+        description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+        type: string
+        default: chrysa-arc
   workflow_dispatch: null
 jobs:
   labels:
     name: Apply labels on pull request
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
     - name: Get Code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@
 jobs:
   labels:
     name: Apply labels on pull request
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner || 'chrysa-arc' }}
     steps:
     - name: Get Code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -12,6 +12,10 @@ on:
                 type: string
                 required: false
                 default: "dev"
+            runner:
+                description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+                type: string
+                default: chrysa-arc
 
 permissions:
     contents: read
@@ -19,7 +23,7 @@ permissions:
 jobs:
     lint:
         name: Ruff + Mypy (pre-commit)
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@v7.0.0

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
     lint:
         name: Ruff + Mypy (pre-commit)
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@v7.0.0

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   mutation:
     name: Mutmut
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner || 'chrysa-arc' }}
     steps:
       - uses: actions/checkout@v7.0.0
 

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -14,6 +14,10 @@ on:
         required: false
         default: "70"
         type: string
+      runner:
+        description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+        type: string
+        default: chrysa-arc
 
 permissions:
   contents: read
@@ -21,7 +25,7 @@ permissions:
 jobs:
   mutation:
     name: Mutmut
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v7.0.0
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
     pages:
         name: Build and deploy docs
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 10
         steps:
             - uses: actions/checkout@v7.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,11 @@ name: GitHub Pages — Documentation
 
 on:
     workflow_call:
+        inputs:
+            runner:
+                description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+                type: string
+                default: chrysa-arc
 
 concurrency:
     group: pages-${{ github.ref }}
@@ -16,7 +21,7 @@ permissions:
 jobs:
     pages:
         name: Build and deploy docs
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 10
         steps:
             - uses: actions/checkout@v7.0.0

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -12,12 +12,17 @@
     - synchronize
   schedule:
   - cron: 0 0 * * *
-  workflow_call: null
+  workflow_call:
+    inputs:
+      runner:
+        description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+        type: string
+        default: chrysa-arc
   workflow_dispatch: null
 jobs:
   check_dependencies:
     name: Check Dependencies
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -22,7 +22,7 @@
 jobs:
   check_dependencies:
     name: Check Dependencies
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner || 'chrysa-arc' }}
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,6 +3,11 @@ name: pre-commit
 
 on:
     workflow_call:
+        inputs:
+            runner:
+                description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+                type: string
+                default: chrysa-arc
 
 permissions:
     contents: read
@@ -10,7 +15,7 @@ permissions:
 jobs:
     pre-commit:
         name: Run pre-commit hooks
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@v7.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
     pre-commit:
         name: Run pre-commit hooks
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@v7.0.0

--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -3,6 +3,11 @@ name: Quality Gate Check
 
 on:
   workflow_call:
+    inputs:
+      runner:
+        description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+        type: string
+        default: chrysa-arc
 
 permissions:
   checks: write
@@ -12,7 +17,7 @@ permissions:
 jobs:
   quality-gate:
     name: No-Regression Quality Gates
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.0

--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   quality-gate:
     name: No-Regression Quality Gates
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner || 'chrysa-arc' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 
 on:
     workflow_call:
+        inputs:
+            runner:
+                description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+                type: string
+                default: chrysa-arc
 
 permissions:
     contents: write
@@ -10,7 +15,7 @@ permissions:
 
 jobs:
     release:
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         name: Create release
         steps:
             - uses: actions/checkout@v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
     release:
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         name: Create release
         steps:
             - uses: actions/checkout@v7.0.0

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -3,11 +3,16 @@ name: Secret scan
 
 on:
     workflow_call:
+        inputs:
+            runner:
+                description: "runs-on label (chrysa-arc self-hosted, or ubuntu-latest for public repos)"
+                type: string
+                default: chrysa-arc
 
 jobs:
     gitleaks:
         name: Detect secrets (Gitleaks)
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         permissions:
             contents: read
             pull-requests: read

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -12,7 +12,7 @@ on:
 jobs:
     gitleaks:
         name: Detect secrets (Gitleaks)
-        runs-on: ${{ inputs.runner }}
+        runs-on: ${{ inputs.runner || 'chrysa-arc' }}
         permissions:
             contents: read
             pull-requests: read

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -42,8 +42,12 @@ pre-commit hooks, with the release gate as the final safety net.
 **Status**: accepted
 
 All reusable workflows (`workflow_call`) in this repository now expose a `runner`
-input (type: string, default: `chrysa-arc`) and set `runs-on: ${{ inputs.runner }}`
-on every job. The self-hosted label `chrysa-arc` is the fleet label for ARC
+input (type: string, default: `chrysa-arc`) and set
+`runs-on: ${{ inputs.runner || 'chrysa-arc' }}` on every job. The explicit
+`|| 'chrysa-arc'` fallback keeps the self-hosted default even on non-`workflow_call`
+trigger paths (e.g. `pull_request_target`, `schedule`), where the input default does
+not apply and `inputs.runner` would otherwise be the empty string. The self-hosted
+label `chrysa-arc` is the fleet label for ARC
 (Actions Runner Controller) runners deployed on the chrysa Kimsufi host.
 
 **Rationale for the public/private split:**

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -35,3 +35,35 @@ Trade-off: PRs are no longer lint-gated in CI; correctness relies on local
 pre-commit hooks, with the release gate as the final safety net.
 
 ---
+
+## D-0003 — Self-hosted runner default (chrysa-arc), public repos override to ubuntu-latest
+
+**Date**: 2026-06-28
+**Status**: accepted
+
+All reusable workflows (`workflow_call`) in this repository now expose a `runner`
+input (type: string, default: `chrysa-arc`) and set `runs-on: ${{ inputs.runner }}`
+on every job. The self-hosted label `chrysa-arc` is the fleet label for ARC
+(Actions Runner Controller) runners deployed on the chrysa Kimsufi host.
+
+**Rationale for the public/private split:**
+Private chrysa repos call the reusable workflows without overriding `runner`, so they
+run on self-hosted `chrysa-arc` runners by default, eliminating GitHub-hosted runner
+billing. Public repos (open-source mirrors, documentation sites) cannot safely route
+CI to private infrastructure, so their caller workflows pass `runner: ubuntu-latest`
+explicitly to force GitHub-hosted runners. The default deliberately favours the private
+fleet; public callers must opt out.
+
+**Affected workflows (16):** `ci-python.yml`, `ci-fullstack.yml`, `ci-python-app.yml`,
+`deploy.yml`, `lint-python.yml`, `mutation-testing.yml`, `dependabot-auto-merge.yml`,
+`dependencies.yml`, `enforce-feature-branch.yml`, `pages.yml`, `pre-commit.yml`,
+`release.yml`, `secret-scan.yml`, `quality-gate-check.yml`, `labeler.yml`,
+`pr-dependencies.yml`.
+
+**Workflows intentionally left unchanged (10):** `action-check.yml`,
+`approved-label.yml`, `auto-assign.yml`, `auto-update-pre-commit.yml`, `ci.yml`,
+`detect-conflicts.yml`, `pull-request-size.yml`, `sonar.yml`, `sync-labels.yml`,
+`update-pr-body.yml` — none of these are triggered by `workflow_call`; they are
+standalone push/PR/schedule workflows owned by this repo and not called by others.
+
+---


### PR DESCRIPTION
## Summary
Recovers the reusable-workflow parametrization that was authored on the `feat/self-hosted-ci` branch but did NOT reach `main` (PR #150 squash-merged only the spec/plan docs — its head was an earlier docs-only commit).

- Every `workflow_call` reusable workflow gains a `runner` input (default `chrysa-arc`); `runs-on` becomes `${{ inputs.runner || 'chrysa-arc' }}` — self-hosted by default on every trigger path, overridable to `ubuntu-latest` by public-repo callers.
- 16 reusable workflows parametrized; ADR **D-0003** added.
- `deploy.yml` carries both this change and the `frontend-target` input from #151 (no conflict).

## Verification
- `actionlint`: clean (only the 2 pre-existing SC2015 info warnings in `ci-fullstack.yml`).

Generated with Claude Code