### PR TITLE
fix(ci): silence SC2015 in ci-fullstack coverage collection

### DIFF
--- a/.github/workflows/ci-fullstack.yml
+++ b/.github/workflows/ci-fullstack.yml
@@ -122,9 +122,9 @@ jobs:
               run: |
                   mkdir -p reports
                   pyc=$(find . -maxdepth 4 -name coverage.xml -not -path './reports/*' | head -1)
-                  [ -n "$pyc" ] && cp "$pyc" reports/coverage.xml || true
+                  if [ -n "$pyc" ]; then cp "$pyc" reports/coverage.xml || true; fi
                   lcov=$(find . -maxdepth 5 -name lcov.info -not -path '*/node_modules/*' | head -1)
-                  [ -n "$lcov" ] && cp "$lcov" reports/lcov.info || true
+                  if [ -n "$lcov" ]; then cp "$lcov" reports/lcov.info || true; fi
                   ls -lh reports/ || true
               shell: bash
             - name: Upload coverage


### PR DESCRIPTION
Replace `[ -n "$x" ] && cp ... || true` with an explicit `if` in the coverage-collection step so shellcheck no longer flags SC2015 (A && B || C is not if-then-else). Behaviour unchanged. `actionlint .github/workflows/*.yml` now exits 0 (previously failed the Actionlint job on main).

Generated with Claude Code