### PR TITLE
chore(ci): add concurrency cancel-in-progress to reusable workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,6 +13,10 @@ permissions:
     contents: write
     pull-requests: write
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     auto-merge:
         runs-on: ${{ inputs.runner || 'chrysa-arc' }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,6 +15,10 @@ permissions:
     issues: write
     pull-requests: write
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     check_dependencies:
         runs-on: ${{ inputs.runner || 'chrysa-arc' }}

--- a/.github/workflows/enforce-feature-branch.yml
+++ b/.github/workflows/enforce-feature-branch.yml
@@ -12,6 +12,10 @@ on:
 permissions:
     contents: read
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     branch-policy:
         if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,9 @@
         type: string
         default: chrysa-arc
   workflow_dispatch: null
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   labels:
     name: Apply labels on pull request

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -20,6 +20,10 @@ on:
 permissions:
     contents: read
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     lint:
         name: Ruff + Mypy (pre-commit)

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   mutation:
     name: Mutmut

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -19,6 +19,9 @@
         type: string
         default: chrysa-arc
   workflow_dispatch: null
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   check_dependencies:
     name: Check Dependencies

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,6 +12,10 @@ on:
 permissions:
     contents: read
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     pre-commit:
         name: Run pre-commit hooks

--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -14,6 +14,10 @@ permissions:
   contents: read
   statuses: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality-gate:
     name: No-Regression Quality Gates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ permissions:
     contents: write
     pull-requests: read
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
 jobs:
     release:
         runs-on: ${{ inputs.runner || 'chrysa-arc' }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -9,6 +9,10 @@ on:
                 type: string
                 default: chrysa-arc
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     gitleaks:
         name: Detect secrets (Gitleaks)


### PR DESCRIPTION
Adds a top-level `concurrency` block to the 11 reusable workflows that lacked one, so superseded runs are cancelled (matters now the fleet targets finite self-hosted runners). `release.yml` uses `cancel-in-progress: false` (a release must not be interrupted); all others `true`. 16/16 reusable workflows now covered. `actionlint` exit 0.

Part of the self-hosted CI hardening (Task 7). Generated with Claude Code