### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,56 +1,74 @@
----
 default_language_version:
   python: python3.14
 fail_fast: false
 minimum_pre_commit_version: 4.1.0
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: fa6b006f0e53d6c0a4a30d6f7b1200a899444634
-      hooks:
-          - id: check-json
-          - id: check-yaml
-            exclude: ^\.github/ISSUE_TEMPLATE/
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
-          - id: detect-private-key
-          - id: no-commit-to-branch
-            args: [--branch, main]
-    - repo: https://github.com/igorshubovych/markdownlint-cli
-      rev: 7a245930f5bc46f67cb592a558604025ed07105d
-      hooks:
-          - id: markdownlint
-            args: [--fix]
-            stages: [manual]
-    - repo: https://github.com/lovesegfault/beautysh
-      rev: 34c3b3da0233e76d7d1ad90a78f3679185ecf31c
-      hooks:
-          - id: beautysh
-            args: [--indent-size, '4']
-    - repo: https://github.com/openstack/bashate
-      rev: ec2f2400915200d633299612a02d7d285e4be24c
-      hooks:
-          - id: bashate
-            args: [--ignore=E006, E020]
-    - repo: https://github.com/chrysa/pre-commit-tools
-      rev: v0.1.1-94
-      hooks:
-          - id: makefile-check
-          - id: yaml-sorter
-            exclude: '^(\.github/|GitVersion\.yml)'
-          - id: json-sorter
-          - id: env-file-check
-          - id: adr-gate
-          - id: regression-gate
-            stages: [pre-push]
-          - id: env-example-sync
-
-    - repo: https://github.com/compilerla/conventional-pre-commit
-      rev: v4.4.0
-      hooks:
-          - id: conventional-pre-commit
-            stages: [commit-msg]
-            args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]
-    - repo: https://github.com/gitleaks/gitleaks
-      rev: v8.30.1
-      hooks:
-          - id: gitleaks
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: fa6b006f0e53d6c0a4a30d6f7b1200a899444634
+  hooks:
+  - id: check-json
+  - id: check-yaml
+    exclude: ^\.github/ISSUE_TEMPLATE/
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: detect-private-key
+  - id: no-commit-to-branch
+    args:
+    - --branch
+    - main
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: 7a245930f5bc46f67cb592a558604025ed07105d
+  hooks:
+  - id: markdownlint
+    args:
+    - --fix
+    stages:
+    - manual
+- repo: https://github.com/lovesegfault/beautysh
+  rev: 34c3b3da0233e76d7d1ad90a78f3679185ecf31c
+  hooks:
+  - id: beautysh
+    args:
+    - --indent-size
+    - '4'
+- repo: https://github.com/openstack/bashate
+  rev: ec2f2400915200d633299612a02d7d285e4be24c
+  hooks:
+  - id: bashate
+    args:
+    - --ignore=E006
+    - E020
+- repo: https://github.com/chrysa/pre-commit-tools
+  rev: v0.1.1-95
+  hooks:
+  - id: makefile-check
+  - id: yaml-sorter
+    exclude: ^(\.github/|GitVersion\.yml)
+  - id: json-sorter
+  - id: env-file-check
+  - id: adr-gate
+  - id: regression-gate
+    stages:
+    - pre-push
+  - id: env-example-sync
+- repo: https://github.com/compilerla/conventional-pre-commit
+  rev: v4.4.0
+  hooks:
+  - id: conventional-pre-commit
+    stages:
+    - commit-msg
+    args:
+    - feat
+    - fix
+    - docs
+    - style
+    - refactor
+    - test
+    - chore
+    - perf
+    - revert
+    - ci
+- repo: https://github.com/gitleaks/gitleaks
+  rev: v8.30.1
+  hooks:
+  - id: gitleaks


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@cf7ad5a75285503e234a47f5b1c10be2ca7d88be`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards