### PR TITLE
ci: concurrency cancel on PR workflows to cut billable minutes (Phase 7 Step 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
     pre-commit:
         name: Pre-commit checks

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -16,6 +16,10 @@ on:
 permissions:
     contents: read
 
+concurrency:
+  group: lint-python-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
     lint:
         name: Ruff + Mypy (pre-commit)

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   mutation:
     name: Mutmut

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,10 @@ on:
 permissions:
     contents: read
 
+concurrency:
+  group: pre-commit-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
     pre-commit:
         name: Run pre-commit hooks

--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -9,6 +9,10 @@ permissions:
   contents: read
   statuses: write
 
+concurrency:
+  group: quality-gate-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality-gate:
     name: No-Regression Quality Gates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ permissions:
     contents: write
     pull-requests: read
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
     release:
         runs-on: ubuntu-latest

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -4,6 +4,10 @@ name: Secret scan
 on:
     workflow_call:
 
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
     gitleaks:
         name: Detect secrets (Gitleaks)

--- a/docs/superpowers/plans/2026-06-28-self-hosted-ci.md
+++ b/docs/superpowers/plans/2026-06-28-self-hosted-ci.md
@@ -322,13 +322,22 @@ git commit -m "ci: adopt v1.3.0 reusable workflows (self-hosted runners)"
 - Consumes: the `v1.3.0` workflows.
 - Produces: `v1.3.1` with reduced redundant runs.
 
-- [ ] **Step 1: Add concurrency cancel** to every PR-triggered reusable workflow:
+- [x] **Step 1: Add concurrency cancel** to the PR-triggered CI workflows (done 2026-07-11,
+  independent of the ARC rollout — helps billable-minute load now):
 
 ```yaml
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: <workflow>-${{ github.ref }}   # hardcoded per-file prefix, NOT github.workflow
   cancel-in-progress: true
 ```
+
+Note: the plan's original `${{ github.workflow }}` prefix is wrong for *reusable*
+(`workflow_call`) workflows — there it resolves to the *caller*, so two reusables
+invoked by one caller would share a group and cancel each other. Each file uses a
+hardcoded unique prefix instead. Applied to `ci`, `lint-python`, `pre-commit`,
+`quality-gate-check`, `secret-scan`, `mutation-testing` (cancel-in-progress: true);
+`release` gets `cancel-in-progress: false` (serialise, never cancel a running
+release). `actionlint` clean. Tagging/distribution stays with the ARC rollout.
 
 - [ ] **Step 2: Add path filters** to the language CI workflows (Python CI ignores frontend/docs-only diffs; Node CI ignores backend-only diffs) via `on.pull_request.paths` in the *caller* templates in `shared-standards/workflows`.
 


### PR DESCRIPTION
Decoupled slice of the self-hosted-CI plan (Phase 7 / Step 1) that helps the org billable-minute load **now**, independent of the ARC rollout.

- `concurrency: { group: <file>-${{ github.ref }}, cancel-in-progress: true }` on the heavy PR-triggered CI workflows (`ci`, `lint-python`, `pre-commit`, `quality-gate-check`, `secret-scan`, `mutation-testing`) → a superseded push cancels its in-flight run.
- `release`: `cancel-in-progress: false` (serialise, never cancel a running release).
- **Fixes the plan's naive snippet**: `${{ github.workflow }}` resolves to the *caller* in a `workflow_call` reusable, so two reusables under one caller would share a group and cancel each other — each file uses a hardcoded unique prefix instead.
- `actionlint` clean. Tagging/distribution stays coupled to the ARC rollout.

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)