### PR TITLE
fix(ci): rewrite A && B || C as if/fi in ci-fullstack coverage copy (SC2015)

### DIFF
--- a/.github/workflows/ci-fullstack.yml
+++ b/.github/workflows/ci-fullstack.yml
@@ -111,9 +111,9 @@ jobs:
               run: |
                   mkdir -p reports
                   pyc=$(find . -maxdepth 4 -name coverage.xml -not -path './reports/*' | head -1)
-                  [ -n "$pyc" ] && cp "$pyc" reports/coverage.xml || true
+                  if [ -n "$pyc" ]; then cp "$pyc" reports/coverage.xml || true; fi
                   lcov=$(find . -maxdepth 5 -name lcov.info -not -path '*/node_modules/*' | head -1)
-                  [ -n "$lcov" ] && cp "$lcov" reports/lcov.info || true
+                  if [ -n "$lcov" ]; then cp "$lcov" reports/lcov.info || true; fi
                   ls -lh reports/ || true
               shell: bash
             - name: Upload coverage


### PR DESCRIPTION
The 'Lint workflows' gate (actionlint + shellcheck) is red on main: shellcheck SC2015 (`A && B || C is not if-then-else`) on the two `[ -n "$x" ] && cp … || true` lines in the coverage-collection step.

Rewrite as `if [ -n "$x" ]; then cp … || true; fi` — identical best-effort semantics (a failed copy still doesn't fail the step), shellcheck clean. Restores the workflow-lint gate to green.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)