### PR TITLE
ci: adopt guideline-checker blocking gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,3 +75,7 @@ repos:
   rev: v8.30.1
   hooks:
   - id: gitleaks
+- repo: https://github.com/chrysa/guideline-checker
+  rev: v1.15.0
+  hooks:
+  - id: guideline-check


### PR DESCRIPTION
Adds the chrysa/guideline-checker pre-commit hook (blocking, --fail-on error). Repo passes clean today (0 errors). Part of the fleet-wide rollout after the validation gate was met.