### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,47 @@ Every repo carries a `runtime:` field in `repos.yml`, machine-checked by `audit-
   `packages:write`), never a plaintext PAT. Distributable libraries publish to public PyPI via
   Trusted Publishing (OIDC), never a token in plaintext.
 
+## Pre-commit & git hooks (native, via pre-commit.com — never wrapped in make)
+
+The enforcement engine is **[pre-commit](https://pre-commit.com/)** itself, configured
+in `.pre-commit-config.yaml`. pre-commit is the authoritative runner; `make lint` /
+`make pre-commit` may exist as thin convenience aliases, but a hook that only runs
+through `make` is a defect — every hook MUST be runnable via `pre-commit run` directly,
+and CI invokes `pre-commit`, not `make`.
+
+- **The gate is host-native — no strong coupling to the project's containers.** pre-commit
+  runs with only `pre-commit` installed on the host (via `pipx`/`uv`, outside any repo); it
+  provisions each hook's isolated environment itself (`~/.cache/pre-commit`), so a commit
+  needs **no project image and no running container**. Local hooks are `language: system` /
+  `python` (or another native language) invoking **host** tools — **never** `docker compose
+  run`, and `language: docker` / `docker_image` is avoided. A check that genuinely needs the
+  project image (Django settings, a DB, a compiled tool) **degrades gracefully on the host**:
+  it probes for the tool and skips with a message when absent
+  (`command -v <tool> >/dev/null 2>&1 && <run> || echo 'skipping — runs in CI/Docker'`),
+  it does **not** spin up a container. Container-side enforcement is CI's job; locally the
+  gate is best-effort and never blocks on the Docker daemon being up. This does not
+  contradict the container-runtime policy — the *application* runs in a container; the
+  *commit gate*, like git, is a host tool.
+- **Two stages, two scopes — do not mix them:**
+  - **commit stage** (`pre-commit run`, default): auto-fixers + fast lints —
+    `ruff`, `end-of-file-fixer`, `trailing-whitespace`, `detect-secrets`/`gitleaks`,
+    `conventional-pre-commit` (commit-msg), `no-commit-to-branch --branch main`.
+    These **mutate** the tree, so they only ever run over the staged/committed diff.
+  - **pre-push stage** (`pre-commit run --hook-stage pre-push`): only hooks tagged
+    `stages: [pre-push]` (e.g. `regression-gate` from `chrysa/pre-commit-tools`), run
+    **natively over the pushed commit range** (`--from-ref <remote>` `--to-ref <local>`).
+    A push **verifies, it never mutates** the tree.
+- **Forbidden at push time:** `make lint`, and `pre-commit run --all-files`. Running the
+  full tree at push re-executes commit-stage **auto-fixers** on unrelated files, mutates
+  them, exits non-zero, and **rejects the push over a pre-existing defect in a file you
+  never touched**. `--all-files` belongs to CI (where a mutation surfaces as a diff) and
+  to a deliberate local audit — never to the push gate.
+- **The global pre-push hook** (`dotfiles/git-hooks-global/pre-push`) mirrors pre-commit's
+  own installed pre-push hook: it runs the `pre-push` stage over the range only, then the
+  SonarCloud quality gate. No `make`, no `--all-files`, no tree mutation.
+- Hooks are **pinned by `rev`**; shared hooks come from `chrysa/pre-commit-tools`.
+  `detect-secrets`/`gitleaks` respect the repo's secret allowlist.
+
 ## Shared skills (load on demand from shared-standards/.claude/skills/)
 
 - `testing-pytest` — pytest DDD + pytest-mock + constants (writing tests)

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "_comment_model": "Model auto-selected from latest Claude available via Copilot. Do not hardcode a version. Fallback: anthropic/claude-sonnet-4-6 if Copilot unavailable.",
+  "instructions": "You are an expert software engineer. Default to English in code, docs, and issues. Respect CLAUDE.md per repo. Use GitHub Copilot (latest Claude) as default model.",
+  "mcp": {
+    "github": {
+      "command": [
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
+      "enabled": true,
+      "environment": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      },
+      "type": "local"
+    },
+    "notion": {
+      "command": [
+        "npx",
+        "-y",
+        "@notionhq/notion-mcp-server"
+      ],
+      "enabled": true,
+      "environment": {
+        "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer ${NOTION_API_KEY}\", \"Notion-Version\": \"2022-06-28\"}"
+      },
+      "type": "local"
+    }
+  },
+  "model": "github-copilot",
+  "provider": {
+    "github-copilot": {
+      "options": {
+        "model": "claude-sonnet-4-6"
+      },
+      "type": "copilot"
+    }
+  }
+}


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@becce0e840d450f421cb92a1a62f27b77e80f46e`
Managed files (inline transverse standards block in `CLAUDE.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards