### PR TITLE
fix(quality-gate-check): install from pyproject so the gates can actually run

### DIFF
--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -31,12 +31,31 @@ jobs:
           node-version: "20"
           cache: npm
       - name: Install dependencies
+        # pyproject.toml is the canonical source (requirements*.txt is only a generated
+        # export, and the standard proscribes it). Installing the project with its
+        # quality extras is what puts pytest/ruff/mypy/detect-secrets on PATH — without
+        # them every gate command exits non-zero and the gate reports a regression that
+        # is really a missing toolchain.
         run: |
-          if [ -f requirements.txt ]; then pip install --only-binary :all: -r requirements.txt; fi
-          if [ -f package.json ]; then npm ci; fi
+          if [ -f pyproject.toml ]; then
+            pip install -e ".[test,lint,typecheck]" \
+              || pip install -e ".[dev]" \
+              || pip install -e .
+            pip install detect-secrets
+          elif [ -f requirements.txt ]; then
+            pip install --only-binary :all: -r requirements.txt
+          fi
+          if [ -f package.json ] && [ -f package-lock.json ]; then npm ci; fi
       - name: Run quality gate verification
         id: quality-gate
-        run: make quality-gate-verify || exit_code=$?; exit "${exit_code:-0}"
+        # A repo with no quality-gate-verify target is not onboarded yet — that is not a
+        # regression, so it must not fail the gate.
+        run: |
+          if make -n quality-gate-verify >/dev/null 2>&1; then
+            make quality-gate-verify
+          else
+            echo "::notice::No 'quality-gate-verify' target found - skipping gate (repo not onboarded)."
+          fi
       - name: Report quality gate status
         if: always()
         run: |


### PR DESCRIPTION
Closes #196

The job installed dependencies only from `requirements.txt`. The standard makes `pyproject.toml` the single source of truth and proscribes `requirements*.txt`, so on a compliant repo **nothing was installed** — every gate exited `command_failed`, Secrets with `exit=127` (command not found). The gate reported a regression that was really a missing toolchain.

That is the worse failure mode: **a gate red for everyone gates nothing**. chrysa/pre-commit-tools had 8 consecutive red runs on `main`, and PRs were merged straight over it.

## Changes

| Before | After |
|---|---|
| `requirements.txt` only | `pip install -e ".[test,lint,typecheck]"` → `.[dev]` → plain `-e .`, with `requirements.txt` kept as fallback |
| Secrets gate had no `detect-secrets` | installed explicitly |
| `npm ci` + `cache: npm` unconditional | gated on `package-lock.json` |
| `make quality-gate-verify` run blind | not-onboarded guard restored (it existed in `v1.3.0`, dropped since — a repo without the target now **failed** instead of being skipped) |

## Blast radius

Every repo calling `quality-gate-check.yml@v1`. The change can only *add* installed packages or *skip* a gate that had no target, so a currently-green repo cannot turn red.

Consumers pin a tag, so this needs a **release** (`v1.3.1`) and a bump in the callers before it takes effect — pinning is why the bug survived this long.

Validated with actionlint (clean).