### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,6 +462,43 @@ Every repo carries a `runtime:` field in `repos.yml`, machine-checked by `audit-
   `packages:write`), never a plaintext PAT. Distributable libraries publish to public PyPI via
   Trusted Publishing (OIDC), never a token in plaintext.
 
+## GitHub Actions (reuse first · custom actions centralised · thin workflows)
+
+CI is assembled from **existing actions**, not written. A workflow is glue — checkout,
+setup, invoke the repo's own gate (`pre-commit`, `make ci`) — and every line of logic it
+carries is a line that lives in the wrong repo.
+
+- **Reuse before writing — always.** The first choice is a **maintained public action**
+  (`actions/checkout`, `actions/setup-python`, `actions/setup-node`, `astral-sh/setup-uv`,
+  `docker/build-push-action`, `SonarSource/*`, `pypa/gh-action-pypi-publish`, …).
+  Re-implementing in a `run:` block something a maintained action already does — caching,
+  toolchain setup, publishing, artifact upload — is a defect. Preferring a hand-rolled
+  script because "it's shorter" is not a reason.
+- **The only home for chrysa-specific actions is `chrysa/github-actions`.** When no public
+  action fits, the behaviour becomes a composite action / reusable workflow in that repo
+  (`python-setup`, `ruff-check`, `run-tests`, `sonar-scan`, `publish-python-package`, …)
+  and consumers reference it: `uses: chrysa/github-actions/<action>@<rev>`. Reusable
+  workflow templates live in `shared-standards/workflows/` and are distributed, never
+  hand-forked.
+- **Repo-local actions are forbidden by default.** No `.github/actions/**` composite in a
+  product repo, no inline bash beyond glue, no `scripts/ci-*.sh` that exists only to be
+  called by a workflow. The **second occurrence of the same CI logic anywhere in the fleet
+  is an extraction order**, not a copy: it moves to `chrysa/github-actions` and both repos
+  consume it. A repo-local action is tolerated only as a short-lived spike, with an issue
+  tracking its migration.
+- **Keep the code minimal.** A job step is a `uses:` or a one-line `run:`. A `run:` block
+  past ~15 lines, or any conditional/parsing/retry logic, does not belong in YAML — it
+  becomes a tested entrypoint inside the action repo (Python preferred, testable), not a
+  heredoc. Duplicated near-identical jobs collapse into a `strategy.matrix`; shared setup
+  collapses into a composite action. Workflow YAML is not a programming language and is
+  not covered by any test.
+- **Pinning & permissions.** Third-party actions are pinned by **commit SHA** (with the
+  version in a trailing comment); `chrysa/github-actions` and `actions/*` by tag.
+  Workflows declare least-privilege `permissions:` (read by default, `packages:write` /
+  `contents:write` only on the job that needs it), never a plaintext PAT where the
+  workflow `GITHUB_TOKEN` or OIDC works. Dependabot keeps the `github-actions` ecosystem
+  up to date.
+
 ## Pre-commit & git hooks (native, via pre-commit.com — never wrapped in make)
 
 The enforcement engine is **[pre-commit](https://pre-commit.com/)** itself, configured
@@ -470,13 +507,25 @@ in `.pre-commit-config.yaml`. pre-commit is the authoritative runner; `make lint
 through `make` is a defect — every hook MUST be runnable via `pre-commit run` directly,
 and CI invokes `pre-commit`, not `make`.
 
+- **Every git hook goes through the framework — no hand-rolled hooks.** A repo's hooks are
+  declared as pre-commit hook ids in `.pre-commit-config.yaml` and installed by
+  `pre-commit install --hook-type pre-commit --hook-type commit-msg --hook-type pre-push`.
+  Hand-written scripts committed under `.git/hooks/` or a repo-local `hooks/` wired via
+  `core.hooksPath`, alternative runners (**husky**, **lefthook**, **overcommit**, npm
+  `prepare` hook installers), and checks reachable only through `make` or a bespoke
+  `scripts/*.sh` are **forbidden**: a gate that is not a pre-commit hook id is not
+  discoverable, not pinned, not skippable per-hook (`SKIP=`), and not runnable in CI the
+  same way. A repo-specific check is a `repo: local` hook in the config (or a hook published
+  by `chrysa/pre-commit-tools`), not a script bolted onto git. The single sanctioned
+  exception is the host-global pre-push (`dotfiles/git-hooks-global/pre-push`), which is
+  machine-level, not repo-level, and itself only invokes `pre-commit`.
 - **The gate is host-native — no strong coupling to the project's containers.** pre-commit
   runs with only `pre-commit` installed on the host (via `pipx`/`uv`, outside any repo); it
   provisions each hook's isolated environment itself (`~/.cache/pre-commit`), so a commit
   needs **no project image and no running container**. Local hooks are `language: system` /
   `python` (or another native language) invoking **host** tools — **never** `docker compose
-  run`, and `language: docker` / `docker_image` is avoided. A check that genuinely needs the
-  project image (Django settings, a DB, a compiled tool) **degrades gracefully on the host**:
+  run`, and `language: docker` / `language: docker_image` is **forbidden**. A check that
+  genuinely needs the project image (Django settings, a DB, a compiled tool) **degrades gracefully on the host**:
   it probes for the tool and skips with a message when absent
   (`command -v <tool> >/dev/null 2>&1 && <run> || echo 'skipping — runs in CI/Docker'`),
   it does **not** spin up a container. Container-side enforcement is CI's job; locally the
@@ -500,6 +549,15 @@ and CI invokes `pre-commit`, not `make`.
 - **The global pre-push hook** (`dotfiles/git-hooks-global/pre-push`) mirrors pre-commit's
   own installed pre-push hook: it runs the `pre-push` stage over the range only, then the
   SonarCloud quality gate. No `make`, no `--all-files`, no tree mutation.
+- **The shared hook package is Docker-free by construction.** `chrysa/pre-commit-tools`
+  — the hook-decentralisation package the whole fleet consumes — publishes every hook as
+  `language: python` (or another native pre-commit language) with its dependencies declared
+  in the hook definition. **Forbidden in that package:** `language: docker`,
+  `language: docker_image`, and any `docker` / `docker compose` invocation inside a hook
+  entrypoint. A published hook MUST run identically on a host where Docker is not installed
+  at all; if a check cannot work without the daemon, it is a CI job, not a hook. This keeps
+  the fleet gate installable with a single `pipx install pre-commit` and immune to the
+  daemon being down.
 - Hooks are **pinned by `rev`**; shared hooks come from `chrysa/pre-commit-tools`.
   `detect-secrets`/`gitleaks` respect the repo's secret allowlist.
 


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@5fd1b4b7dab38399821ca8bf7e4ee39be8e8ad05`
Managed files (inline transverse standards block in `CLAUDE.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards