### PR TITLE
fix(workflows): declare workflow_call on the seven reusable workflows missing it

### DIFF
--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -10,6 +10,7 @@
     - master
     paths:
     - .github/workflows/**
+  workflow_call: null
 jobs:
   actionlint:
     name: Lint workflows

--- a/.github/workflows/approved-label.yml
+++ b/.github/workflows/approved-label.yml
@@ -1,4 +1,6 @@
-"on": pull_request_review
+"on":
+  pull_request_review: null
+  workflow_call: null
 concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -4,6 +4,7 @@
     - opened
     - ready_for_review
     - reopened
+  workflow_call: null
 jobs:
   add-reviews:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-update-pre-commit.yml
+++ b/.github/workflows/auto-update-pre-commit.yml
@@ -2,6 +2,7 @@
   schedule:
   - cron: 0 5 * * 1
   workflow_dispatch: null
+  workflow_call: null
 jobs:
   pre-commit-autoupdate:
     name: Bump pre-commit hooks

--- a/.github/workflows/detect-conflicts.yml
+++ b/.github/workflows/detect-conflicts.yml
@@ -4,6 +4,7 @@
     - opened
     - reopened
     - synchronize
+  workflow_call: null
 concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pull-request-size.yml
+++ b/.github/workflows/pull-request-size.yml
@@ -1,4 +1,6 @@
-"on": pull_request_target
+"on":
+  pull_request_target: null
+  workflow_call: null
 jobs:
   size-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -9,6 +9,7 @@
   schedule:
   - cron: 0 2 * * 1
   workflow_dispatch: null
+  workflow_call: null
 jobs:
   sync-labels:
     name: Synchronize labels


### PR DESCRIPTION
Closes #209

Seven workflows are distributed as reusable and called with `uses:` across the fleet, but none declared `on: workflow_call`:

`action-check` · `approved-label` · `auto-assign` · `auto-update-pre-commit` · `detect-conflicts` · `pull-request-size` · `sync-labels`

GitHub refuses the call, so consumers get **startup_failure / "this run likely failed because of a workflow file issue"** — the one failure shape with **no log and no red check on the PR**. That is why it went unnoticed: the automation was not failing loudly, it was failing invisibly.

Evidence, last 40 runs on chrysa/pre-commit-tools:

```
2 failure  .github/workflows/update-pr-body.yml
2 failure  .github/workflows/pull-request-size.yml
2 failure  .github/workflows/detect-conflicts.yml
2 failure  .github/workflows/auto-assign.yml
```

So conflict detection, PR sizing, reviewer assignment, label sync, the approved label, actionlint and the weekly pre-commit bump have been **dead in every consumer repo**, while the repos looked green.

## Change

One `workflow_call: null` per file. Additive — each workflow keeps its own triggers (`pull_request`, `schedule`, `pull_request_review`…) and merely becomes callable. Two files also needed their inline `"on": <event>` expanded to block form.

actionlint clean over the whole workflow directory.