### PR TITLE
fix(notion): drop typing.Any, report coverage to SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
                   python-version: "3.14"
 
             - name: Install test dependencies
-              run: pip install --quiet pytest pyyaml
+              run: "pip install --quiet --only-binary :all: pytest==8.4.2 pytest-mock==3.15.1 pyyaml==6.0.3"
 
             - name: Run test suite
               run: pytest

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -50,7 +50,7 @@ jobs:
                       -Dsonar.tests=tests
                       -Dsonar.python.coverage.reportPaths=coverage.xml
                       -Dsonar.sourceEncoding=UTF-8
-                      -Dsonar.exclusions=**/__pycache__/**,**/*.pyc,**/.mypy_cache/**
+                      -Dsonar.exclusions=tests/**,**/__pycache__/**,**/*.pyc,**/.mypy_cache/**
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -32,11 +32,11 @@ jobs:
               uses: actions/checkout@v7.0.1
               with:
                   fetch-depth: 0
-            - uses: chrysa/github-actions/python-setup@v1.4.4
+            - uses: chrysa/github-actions/python-setup@05f91eb1fc78ffad759e1ca904161b4875f466a5 # v1.4.4
               with:
                   python-version: "3.14"
             - name: Install test dependencies
-              run: pip install --quiet pytest pytest-cov pyyaml
+              run: "pip install --quiet --only-binary :all: pytest==8.4.2 pytest-cov==7.0.0 pytest-mock==3.15.1 pyyaml==6.0.3"
             - name: Run tests with coverage
               run: pytest --cov=notion_sync --cov-report=xml:coverage.xml
             - name: SonarCloud scan

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -32,6 +32,13 @@ jobs:
               uses: actions/checkout@v7.0.1
               with:
                   fetch-depth: 0
+            - uses: chrysa/github-actions/python-setup@v1.4.4
+              with:
+                  python-version: "3.14"
+            - name: Install test dependencies
+              run: pip install --quiet pytest pytest-cov pyyaml
+            - name: Run tests with coverage
+              run: pytest --cov=notion_sync --cov-report=xml:coverage.xml
             - name: SonarCloud scan
               uses: SonarSource/sonarqube-scan-action@v8.2.1
               with:
@@ -40,6 +47,8 @@ jobs:
                       -Dsonar.organization=chrysa
                       -Dsonar.projectName=github-actions
                       -Dsonar.sources=.
+                      -Dsonar.tests=tests
+                      -Dsonar.python.coverage.reportPaths=coverage.xml
                       -Dsonar.sourceEncoding=UTF-8
                       -Dsonar.exclusions=**/__pycache__/**,**/*.pyc,**/.mypy_cache/**
               env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,9 +63,9 @@ repos:
   - id: debugger-detection
     exclude: ^(tests?/|README\.md|docs/)
   - id: python-print-detection
-    exclude: ^(tests?/|README\.md|docs/)
+    exclude: ^(tests?/|README\.md|docs/|\.claude/)
   - id: python-pprint-detection
-    exclude: ^(tests?/|README\.md|docs/)
+    exclude: ^(tests?/|README\.md|docs/|\.claude/)
   - id: no-bare-except
   - id: python-logger-detection
     exclude: ^(tests?/|README\.md|docs/)

--- a/notion_sync/branch_sync.py
+++ b/notion_sync/branch_sync.py
@@ -7,6 +7,7 @@ import os
 import re
 import urllib.parse
 
+from notion_sync.logging_setup import configure, get_logger
 from notion_sync.notion_api import (
     NotionSyncError,
     github_request,
@@ -30,6 +31,9 @@ CI_CONCLUSION_TO_STATUS = {
     "failure": "failing",
     "timed_out": "failing",
 }
+
+
+logger = get_logger(__name__)
 
 
 def normalise_date(timestamp: str) -> str:
@@ -133,13 +137,14 @@ def _sync_roadmap_row(excerpt: str, branch: str) -> None:
     if len(cells) > CELL_LAST_UPDATE:
         cells[CELL_LAST_UPDATE] = rich_text(datetime.date.today().isoformat())
     notion_request("PATCH", f"blocks/{block_id}", {"table_row": {"cells": cells}})
-    print(f"Roadmap row {block_id[:8]} changelog synced")
+    logger.info(f"Roadmap row {block_id[:8]} changelog synced")
 
 
 def main() -> int:
+    configure()
     database_id = os.environ.get("NOTION_BRANCHES_DB_ID", "").strip()
     if not database_id:
-        print("NOTION_BRANCHES_DB_ID not set — skipping")
+        logger.info("NOTION_BRANCHES_DB_ID not set — skipping")
         return 0
 
     context = read_context(dict(os.environ))
@@ -165,7 +170,7 @@ def main() -> int:
 
     if not response:
         raise NotionSyncError(f"could not sync {context['repo_short']}/{context['branch']} to Notion")
-    print(
+    logger.info(
         f"Notion branch entry {action}: {context['repo_short']}/{context['branch']} "
         f"(sha={context['sha']}, ci={status}, prs={pr_count})"
     )

--- a/notion_sync/branch_sync.py
+++ b/notion_sync/branch_sync.py
@@ -6,7 +6,6 @@ import datetime
 import os
 import re
 import urllib.parse
-from typing import Any
 
 from notion_sync.notion_api import (
     NotionSyncError,
@@ -60,18 +59,19 @@ def read_changelog_excerpt(path: str = CHANGELOG_PATH) -> str:
         return changelog_excerpt(handle.read())
 
 
-def ci_status(runs: dict[str, Any] | None) -> str:
+def ci_status(runs: object) -> str:
     """Map the latest workflow run conclusion to the Notion CI status value."""
-    workflow_runs = (runs or {}).get("workflow_runs") if isinstance(runs, dict) else None
-    if not workflow_runs:
+    workflow_runs = runs.get("workflow_runs") if isinstance(runs, dict) else None
+    if not isinstance(workflow_runs, list) or not workflow_runs:
         return "unknown"
-    conclusion = workflow_runs[0].get("conclusion") or "unknown"
+    latest = workflow_runs[0]
+    conclusion = (latest.get("conclusion") if isinstance(latest, dict) else None) or "unknown"
     return CI_CONCLUSION_TO_STATUS.get(conclusion, "unknown")
 
 
-def build_properties(context: dict[str, str], pr_count: int, status: str, excerpt: str) -> dict[str, Any]:
+def build_properties(context: dict[str, str], pr_count: int, status: str, excerpt: str) -> dict[str, object]:
     """Build the Notion page properties for one branch row."""
-    properties: dict[str, Any] = {
+    properties: dict[str, object] = {
         "Branch": {"title": rich_text(context["branch"])},
         "Repo": {"rich_text": rich_text(context["repo_short"])},
         "Status": {"select": {"name": "active"}},
@@ -112,8 +112,12 @@ def _find_existing_page(database_id: str, context: dict[str, str]) -> str | None
         }
     }
     result = notion_request("POST", f"databases/{database_id}/query", query)
-    results = (result or {}).get("results", [])
-    return results[0]["id"] if results else None
+    results = result.get("results") if isinstance(result, dict) else None
+    if not isinstance(results, list) or not results:
+        return None
+    first = results[0]
+    page_id = first.get("id") if isinstance(first, dict) else None
+    return str(page_id) if page_id else None
 
 
 def _sync_roadmap_row(excerpt: str, branch: str) -> None:

--- a/notion_sync/logging_setup.py
+++ b/notion_sync/logging_setup.py
@@ -1,0 +1,20 @@
+"""Logging wired to the GitHub Actions log stream.
+
+Actions read stdout: a plain message is a log line, `::warning::…` is an annotation.
+So the formatter emits the message verbatim — no timestamps, no level prefix.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger writing bare messages to stdout (the Actions log channel)."""
+    return logging.getLogger(name)
+
+
+def configure() -> None:
+    """Install the stdout handler once, at entrypoint start."""
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(message)s", force=True)

--- a/notion_sync/notion_api.py
+++ b/notion_sync/notion_api.py
@@ -6,7 +6,6 @@ import json
 import os
 import urllib.error
 import urllib.request
-from typing import Any
 
 NOTION_API_ROOT = "https://api.notion.com/v1/"
 GITHUB_API_ROOT = "https://api.github.com/"
@@ -29,7 +28,7 @@ class NotionSyncError(RuntimeError):
     """A Notion or GitHub call failed in a way the caller must handle."""
 
 
-def rich_text(content: object) -> list[dict[str, Any]]:
+def rich_text(content: object) -> list[dict[str, object]]:
     """Build a Notion `rich_text` payload from any printable value."""
     text = str(content)[:RICH_TEXT_MAX_CHARS]
     return [
@@ -42,7 +41,7 @@ def rich_text(content: object) -> list[dict[str, Any]]:
     ]
 
 
-def _request(url: str, headers: dict[str, str], method: str, body: object | None) -> Any | None:
+def _request(url: str, headers: dict[str, str], method: str, body: object | None) -> object | None:
     data = json.dumps(body).encode() if body is not None else None
     request = urllib.request.Request(url, data=data, method=method, headers=headers)
     try:
@@ -55,7 +54,7 @@ def _request(url: str, headers: dict[str, str], method: str, body: object | None
     return None
 
 
-def notion_request(method: str, path: str, body: object | None = None) -> Any | None:
+def notion_request(method: str, path: str, body: object | None = None) -> object | None:
     """Call the Notion API. Returns the decoded body, or None when the call failed."""
     token = os.environ.get("NOTION_TOKEN", "")
     if not token:
@@ -68,7 +67,7 @@ def notion_request(method: str, path: str, body: object | None = None) -> Any | 
     return _request(NOTION_API_ROOT + path.lstrip("/"), headers, method, body)
 
 
-def github_request(path: str) -> Any | None:
+def github_request(path: str) -> object | None:
     """Read the GitHub API with the workflow token. Returns None when the call failed."""
     headers = {
         "Authorization": f"Bearer {os.environ.get('GITHUB_TOKEN', '')}",
@@ -78,8 +77,10 @@ def github_request(path: str) -> Any | None:
     return _request(GITHUB_API_ROOT + path.lstrip("/"), headers, "GET", None)
 
 
-def table_row_cells(block: dict[str, Any]) -> list[Any]:
+def table_row_cells(block: object) -> list[object]:
     """Extract the cells of a Notion table-row block."""
-    row_type = block.get("type", "table_row")
-    cells = block.get(row_type, {}).get("cells", [])
+    if not isinstance(block, dict):
+        return []
+    row = block.get(block.get("type", "table_row"), {})
+    cells = row.get("cells", []) if isinstance(row, dict) else []
     return list(cells) if isinstance(cells, list) else []

--- a/notion_sync/notion_api.py
+++ b/notion_sync/notion_api.py
@@ -7,6 +7,10 @@ import os
 import urllib.error
 import urllib.request
 
+from notion_sync.logging_setup import get_logger
+
+logger = get_logger(__name__)
+
 NOTION_API_ROOT = "https://api.notion.com/v1/"
 GITHUB_API_ROOT = "https://api.github.com/"
 NOTION_VERSION = "2022-06-28"
@@ -48,9 +52,9 @@ def _request(url: str, headers: dict[str, str], method: str, body: object | None
         with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
             return json.loads(response.read())
     except urllib.error.HTTPError as error:
-        print(f"::warning::{method} {url} failed ({error.code}): {error.read().decode()[:500]}")
+        logger.info(f"::warning::{method} {url} failed ({error.code}): {error.read().decode()[:500]}")
     except (urllib.error.URLError, TimeoutError, ValueError) as error:
-        print(f"::warning::{method} {url} failed: {error}")
+        logger.info(f"::warning::{method} {url} failed: {error}")
     return None
 
 

--- a/notion_sync/roadmap_sync.py
+++ b/notion_sync/roadmap_sync.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import datetime
 import os
 
+from notion_sync.logging_setup import configure, get_logger
 from notion_sync.notion_api import notion_request, rich_text, table_row_cells
 
 TASK_TITLE_MAX_CHARS = 55
 CELL_CURRENT_TASK = 4
 CELL_LAST_UPDATE = 7
+
+
+logger = get_logger(__name__)
 
 
 def build_task_label(env: dict[str, str]) -> str:
@@ -38,20 +42,21 @@ def updated_cells(cells: list[object], task: str, today: str) -> list[object]:
 
 
 def main() -> int:
+    configure()
     block_id = os.environ.get("NOTION_BLOCK_ID", "").strip()
     if not block_id or not os.environ.get("NOTION_TOKEN", ""):
-        print("Missing NOTION_TOKEN or NOTION_BLOCK_ID — skipping")
+        logger.info("Missing NOTION_TOKEN or NOTION_BLOCK_ID — skipping")
         return 0
 
     block = notion_request("GET", f"blocks/{block_id}")
     if not block:
-        print("::warning::roadmap row unreadable — skipping")
+        logger.info("::warning::roadmap row unreadable — skipping")
         return 0
 
     task = build_task_label(dict(os.environ))
     cells = updated_cells(table_row_cells(block), task, datetime.date.today().isoformat())
     notion_request("PATCH", f"blocks/{block_id}", {"table_row": {"cells": cells}})
-    print(f"Notion roadmap row {block_id[:8]} → {task}")
+    logger.info(f"Notion roadmap row {block_id[:8]} → {task}")
     return 0
 
 

--- a/notion_sync/roadmap_sync.py
+++ b/notion_sync/roadmap_sync.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import datetime
 import os
-from typing import Any
 
 from notion_sync.notion_api import notion_request, rich_text, table_row_cells
 
@@ -28,7 +27,7 @@ def build_task_label(env: dict[str, str]) -> str:
     return f"{event} [{action}]"
 
 
-def updated_cells(cells: list[Any], task: str, today: str) -> list[Any]:
+def updated_cells(cells: list[object], task: str, today: str) -> list[object]:
     """Return the row cells with the current-task and last-update columns refreshed."""
     updated = list(cells)
     if len(updated) > CELL_CURRENT_TASK:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,5 +2,7 @@ sonar.projectKey=chrysa_github-actions
 sonar.organization=chrysa
 sonar.projectName=github-actions
 sonar.sources=.
+sonar.tests=tests
+sonar.python.coverage.reportPaths=coverage.xml
 sonar.sourceEncoding=UTF-8
 sonar.exclusions=**/__pycache__/**,**/*.pyc,**/.mypy_cache/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,4 +5,4 @@ sonar.sources=.
 sonar.tests=tests
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.sourceEncoding=UTF-8
-sonar.exclusions=**/__pycache__/**,**/*.pyc,**/.mypy_cache/**
+sonar.exclusions=tests/**,**/__pycache__/**,**/*.pyc,**/.mypy_cache/**

--- a/tests/test_notion_api.py
+++ b/tests/test_notion_api.py
@@ -1,0 +1,89 @@
+"""Unit tests for the Notion/GitHub HTTP helpers — no real network."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from typing import TYPE_CHECKING
+
+import pytest
+
+from notion_sync import notion_api
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+class _FakeResponse:
+    def __init__(self, payload: object) -> None:
+        self._payload = json.dumps(payload).encode()
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+def test_rich_text_truncates_and_stringifies() -> None:
+    element = notion_api.rich_text(42)[0]
+
+    assert element["text"] == {"content": "42"}
+    assert element["plain_text"] == "42"
+
+    long_element = notion_api.rich_text("x" * 5000)[0]
+
+    assert len(long_element["plain_text"]) == notion_api.RICH_TEXT_MAX_CHARS
+
+
+def test_notion_request_sends_token_and_returns_payload(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", {"NOTION_TOKEN": "secret-token"}, clear=False)
+    urlopen = mocker.patch.object(notion_api.urllib.request, "urlopen", return_value=_FakeResponse({"ok": True}))
+
+    result = notion_api.notion_request("POST", "pages", {"a": 1})
+
+    assert result == {"ok": True}
+    request = urlopen.call_args.args[0]
+    assert request.full_url == "https://api.notion.com/v1/pages"
+    assert request.get_method() == "POST"
+    assert request.headers["Authorization"] == "Bearer secret-token"
+    assert request.headers["Notion-version"] == notion_api.NOTION_VERSION
+
+
+def test_notion_request_without_token_raises(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", {"NOTION_TOKEN": ""}, clear=False)
+
+    with pytest.raises(notion_api.NotionSyncError):
+        notion_api.notion_request("GET", "pages/1")
+
+
+def test_request_returns_none_on_http_error(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", {"NOTION_TOKEN": "t"}, clear=False)
+    error = urllib.error.HTTPError("https://api.notion.com/v1/pages", 400, "Bad", {}, None)
+    mocker.patch.object(error, "read", return_value=b"boom")
+    mocker.patch.object(notion_api.urllib.request, "urlopen", side_effect=error)
+
+    assert notion_api.notion_request("GET", "pages/1") is None
+
+
+def test_request_returns_none_on_url_error(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", {"GITHUB_TOKEN": "t"}, clear=False)
+    mocker.patch.object(notion_api.urllib.request, "urlopen", side_effect=urllib.error.URLError("down"))
+
+    assert notion_api.github_request("repos/chrysa/x/pulls") is None
+
+
+def test_github_request_targets_the_rest_api(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", {"GITHUB_TOKEN": "gh-token"}, clear=False)
+    urlopen = mocker.patch.object(notion_api.urllib.request, "urlopen", return_value=_FakeResponse([1, 2]))
+
+    assert notion_api.github_request("repos/chrysa/x/pulls") == [1, 2]
+    assert urlopen.call_args.args[0].full_url == "https://api.github.com/repos/chrysa/x/pulls"
+
+
+def test_table_row_cells_rejects_non_mappings() -> None:
+    assert notion_api.table_row_cells("nope") == []
+    assert notion_api.table_row_cells({"type": "table_row", "table_row": {"cells": "bad"}}) == []

--- a/tests/test_sync_entrypoints.py
+++ b/tests/test_sync_entrypoints.py
@@ -1,0 +1,122 @@
+"""Entrypoint-level tests: the main() flows with every network call mocked."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from notion_sync import branch_sync, roadmap_sync
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+BRANCH_ENV = {
+    "NOTION_BRANCHES_DB_ID": "db-1",
+    "NOTION_TOKEN": "t",
+    "REPO_NAME": "chrysa/github-actions",
+    "BRANCH_NAME": "main",
+    "COMMIT_SHA": "0123456789",
+    "COMMIT_MSG": "feat: x",
+    "COMMIT_AUTHOR": "chrysa",
+    "COMMIT_TS": "2026-07-31T10:00:00Z",
+    "NOTION_PROJECT_BLOCK_ID": "",
+}
+
+
+def test_branch_sync_skips_without_database_id(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", {"NOTION_BRANCHES_DB_ID": ""}, clear=False)
+
+    assert branch_sync.main() == 0
+
+
+def test_branch_sync_creates_a_row_when_none_exists(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", BRANCH_ENV, clear=False)
+    mocker.patch.object(branch_sync, "read_changelog_excerpt", return_value="")
+    mocker.patch.object(branch_sync, "github_request", return_value=[])
+    notion = mocker.patch.object(branch_sync, "notion_request", side_effect=[{"results": []}, {"id": "page-1"}])
+
+    assert branch_sync.main() == 0
+    assert notion.call_args_list[-1].args[0] == "POST"
+    assert notion.call_args_list[-1].args[1] == "pages"
+
+
+def test_branch_sync_updates_the_existing_row(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", BRANCH_ENV, clear=False)
+    mocker.patch.object(branch_sync, "read_changelog_excerpt", return_value="")
+    mocker.patch.object(branch_sync, "github_request", return_value=[])
+    notion = mocker.patch.object(
+        branch_sync, "notion_request", side_effect=[{"results": [{"id": "page-9"}]}, {"id": "page-9"}]
+    )
+
+    assert branch_sync.main() == 0
+    assert notion.call_args_list[-1].args[:2] == ("PATCH", "pages/page-9")
+
+
+def test_branch_sync_raises_when_notion_write_fails(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", BRANCH_ENV, clear=False)
+    mocker.patch.object(branch_sync, "read_changelog_excerpt", return_value="")
+    mocker.patch.object(branch_sync, "github_request", return_value=[])
+    mocker.patch.object(branch_sync, "notion_request", side_effect=[{"results": []}, None])
+
+    try:
+        branch_sync.main()
+    except branch_sync.NotionSyncError:
+        return
+    raise AssertionError("a failed Notion write must raise")
+
+
+def test_branch_sync_pushes_the_changelog_to_the_roadmap_row(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", {**BRANCH_ENV, "NOTION_PROJECT_BLOCK_ID": "block-1"}, clear=False)
+    mocker.patch.object(branch_sync, "read_changelog_excerpt", return_value="[1.0.0]\nnote")
+    mocker.patch.object(branch_sync, "github_request", return_value=[{"number": 1}])
+    row = {"type": "table_row", "table_row": {"cells": [f"c{i}" for i in range(9)]}}
+    notion = mocker.patch.object(
+        branch_sync, "notion_request", side_effect=[{"results": []}, {"id": "p"}, row, {"id": "block-1"}]
+    )
+
+    assert branch_sync.main() == 0
+    method, path, body = notion.call_args_list[-1].args
+    assert (method, path) == ("PATCH", "blocks/block-1")
+    assert body["table_row"]["cells"][branch_sync.CELL_CURRENT_TASK][0]["text"]["content"] == "[1.0.0]"
+
+
+def test_branch_sync_reads_the_changelog_from_disk(tmp_path, mocker: MockerFixture) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("## [9.9.9]\n\n- shipped\n", encoding="utf-8")
+
+    assert branch_sync.read_changelog_excerpt(str(changelog)).startswith("[9.9.9]")
+    assert branch_sync.read_changelog_excerpt(str(tmp_path / "missing.md")) == ""
+
+
+def test_roadmap_sync_skips_without_configuration(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", {"NOTION_BLOCK_ID": "", "NOTION_TOKEN": ""}, clear=False)
+
+    assert roadmap_sync.main() == 0
+
+
+def test_roadmap_sync_skips_when_the_row_is_unreadable(mocker: MockerFixture) -> None:
+    mocker.patch.dict("os.environ", {"NOTION_BLOCK_ID": "b", "NOTION_TOKEN": "t"}, clear=False)
+    mocker.patch.object(roadmap_sync, "notion_request", return_value=None)
+
+    assert roadmap_sync.main() == 0
+
+
+def test_roadmap_sync_patches_the_row(mocker: MockerFixture) -> None:
+    mocker.patch.dict(
+        "os.environ",
+        {
+            "NOTION_BLOCK_ID": "b",
+            "NOTION_TOKEN": "t",
+            "GITHUB_EVENT_NAME": "issues",
+            "GITHUB_EVENT_ACTION": "opened",
+            "ISSUE_NUMBER": "3",
+            "ISSUE_TITLE": "bug",
+        },
+        clear=False,
+    )
+    row = {"type": "table_row", "table_row": {"cells": [f"c{i}" for i in range(9)]}}
+    notion = mocker.patch.object(roadmap_sync, "notion_request", side_effect=[row, {"id": "b"}])
+
+    assert roadmap_sync.main() == 0
+    method, path, body = notion.call_args_list[-1].args
+    assert (method, path) == ("PATCH", "blocks/b")
+    assert body["table_row"]["cells"][roadmap_sync.CELL_CURRENT_TASK][0]["text"]["content"] == "Issue#3 bug [opened]"


### PR DESCRIPTION
Follow-up to #212 — it auto-merged (bot) before these two fixes were pushed to the branch.

- **typing.Any removed** from `notion_sync/*`: the guideline gate flags `Any`; the JSON boundaries now take `object` with `isinstance` guards (Notion/GitHub payloads are untrusted anyway).
- **Coverage reported to Sonar**: the quality gate failed on new-code coverage because no report existed. The sonar job now installs pytest+pytest-cov, runs `pytest --cov=notion_sync --cov-report=xml`, and passes `sonar.python.coverage.reportPaths` / `sonar.tests`.

30 tests still green.