### PR TITLE
fix(quality-gate): install the host tools the gate shells out to

### DIFF
--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -45,10 +45,22 @@ jobs:
             pip install -e ".[dev]" \
               || pip install -e ".[test,lint,typecheck]" \
               || pip install -e .
-            pip install detect-secrets
           elif [ -f requirements.txt ]; then
             pip install --only-binary :all: -r requirements.txt
           fi
+          # The gate shells out to these four on the host. A repo's extras may or may
+          # not carry them, and when one is absent the gate command exits 127 — which
+          # the gate reads as a regression that is really a missing toolchain.
+          # Install only what the project install did not already provide, so a repo
+          # that pins its own ruff/mypy keeps that version.
+          for tool in ruff mypy detect-secrets pip-audit; do
+            if command -v "$tool" >/dev/null 2>&1; then
+              echo "::debug::${tool} already on PATH ($(command -v "$tool"))"
+            else
+              echo "::notice::${tool} missing from the project install - adding it for the gate"
+              pip install "$tool"
+            fi
+          done
           if [ -f package.json ] && [ -f package-lock.json ]; then npm ci; fi
       - name: Run quality gate verification
         id: quality-gate


### PR DESCRIPTION
Reported from chrysa/guideline-checker#310.

`quality-gate-check.yml` runs seven gates. Tests and Coverage go through Docker and pass; the other four shell out to host tools:

| gate | tool | installed by the job before this PR |
|---|---|---|
| Lint | ruff | only if the repo's extras happen to carry it |
| Types | mypy | idem |
| Secrets | detect-secrets | ✅ explicitly |
| VulnDeps | pip-audit | ❌ never |

When a tool is absent the command exits **127**, and the gate — correctly, since guideline-checker#308 stopped `swallow_exit` from eating 127 — reports a regression. Observed there as `Lint FAIL exit=2` / `Types FAIL exit=2` on a green tree.

## Change
After the project install, loop over `ruff mypy detect-secrets pip-audit` and `pip install` only the ones not already on `PATH`. A repo that pins its own ruff/mypy keeps that version — installing them unconditionally would silently upgrade to latest and change the findings.

Missing tools are announced with `::notice::`, so a repo that is quietly relying on the fallback is visible in the log rather than invisible.

## Note
This unblocks the four gates. Consumers pinning an older tag (guideline-checker is on `@v1.3.0`) need a pin bump to pick it up.