### PR TITLE
fix(quality-gate): skip pip install for a tooling-only pyproject, cache npm only with a lockfile

### DIFF
--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -24,12 +24,24 @@ jobs:
         uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.14"
+      # `cache: npm` errors out ("Dependencies lock file is not found") on every repo
+      # without a JS lockfile — which is most of the fleet. The step survives on
+      # continue-on-error, but it prints a red ##[error] in the log of a passing gate,
+      # which is how a real failure gets missed. Cache only when there is a lockfile.
+      - name: Detect a JS lockfile
+        id: js
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ] || [ -f yarn.lock ]; then
+            echo "cache=npm" >> "$GITHUB_OUTPUT"
+          else
+            echo "cache=" >> "$GITHUB_OUTPUT"
+          fi
       - name: Set up Node.js (if needed)
         continue-on-error: true
         uses: actions/setup-node@v7.0.0
         with:
           node-version: "20"
-          cache: npm
+          cache: ${{ steps.js.outputs.cache }}
       - name: Install dependencies
         # pyproject.toml is the canonical source (requirements*.txt is only a generated
         # export, and the standard proscribes it). Installing the project with its
@@ -41,7 +53,12 @@ jobs:
           # suite collects. A narrower `[test,lint,typecheck]` can miss an extra a test
           # module imports — collection then aborts and the coverage gate reports a
           # regression that is really a partial run.
-          if [ -f pyproject.toml ]; then
+          # A pyproject.toml without a [project] table is TOOLING CONFIG, not a package
+          # (ruff/mypy/pytest settings for a repo of scripts). `pip install -e .` on such
+          # a tree fails on setuptools flat-layout auto-discovery ("Multiple top-level
+          # packages discovered"), and the gate reports a regression that is really "this
+          # repo was never installable". Only install when the project declares itself.
+          if [ -f pyproject.toml ] && grep -q '^\[project\]' pyproject.toml; then
             pip install -e ".[dev]" \
               || pip install -e ".[test,lint,typecheck]" \
               || pip install -e .


### PR DESCRIPTION
Two false regressions reported by `quality-gate-check.yml` on repos that are not Python packages.

**1. Tooling-only `pyproject.toml`** — a `pyproject.toml` with no `[project]` table is tooling config (ruff/mypy/pytest settings for a repo of scripts). The step ran `pip install -e .` anyway, setuptools flat-layout auto-discovery blew up:

```
error: Multiple top-level packages discovered in a flat-layout: ['annexes', 'manifest', 'windows11'].
```

…and the gate reported a regression that was really "this repo was never installable". Now guarded by `grep -q '^\[project\]'`. Observed on `chrysa/windows-autonome` (blocked its standards-sync PR).

**2. `cache: npm` without a lockfile** — errors on most of the fleet ("Dependencies lock file is not found"). `continue-on-error` kept the job alive, but a red `##[error]` in the log of a *passing* gate is how a real failure gets missed. A detect step now enables the cache only when `package-lock.json` / `npm-shrinkwrap.json` / `yarn.lock` exists.

Follow-up (not in this PR): most of the fleet still pins these reusable workflows at `v1.4.4`, which predates the `make -n quality-gate-verify` guard — that is the systemic cause of red quality-gate checks across repos.