### PR TITLE
feat(lint): centralise the infra lint actions extracted from chrysa/server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Shared composite GitHub Actions for `chrysa/*` repositories.
 | `chrysa/github-actions/publish-python-package@main` | Build + publish Python package to PyPI |
 | `chrysa/github-actions/notion-branch-sync@main` | Sync the pushed branch to the Notion Branch Activity database |
 | `chrysa/github-actions/notion-roadmap-sync@main` | Sync an issue/PR event to the Notion roadmap row |
+| `chrysa/github-actions/lint-yaml@main` | yamllint over the repo's YAML |
+| `chrysa/github-actions/lint-bash@main` | shellcheck + shfmt over shell scripts |
+| `chrysa/github-actions/lint-docker@main` | hadolint over Dockerfiles |
+| `chrysa/github-actions/lint-helm@main` | `helm lint --strict` per chart |
+| `chrysa/github-actions/validate-terraform@main` | terraform init/validate/fmt (never applies) |
 
 ## Usage
 
@@ -282,3 +287,28 @@ Sync an issue or pull-request event to the project's Notion roadmap table row.
 
 Action logic that outgrows a one-line `run:` lives in `notion_sync/` and is unit-tested
 (`tests/`, run by `make test`) — workflows stay glue, per the fleet GitHub Actions standard.
+
+### lint-yaml / lint-bash / lint-docker / lint-helm / validate-terraform
+
+Infrastructure linters extracted from `chrysa/server`, where they lived as repo-local
+composite actions. Every path/version is an input, so any repo can consume them.
+
+```yaml
+- uses: chrysa/github-actions/lint-yaml@main
+  with:
+    config-file: .yamllint.yaml
+    exclude-paths: "./.git/* ./archive/*"
+
+- uses: chrysa/github-actions/lint-bash@main       # severity, indent, exclude-paths
+- uses: chrysa/github-actions/lint-docker@main     # hadolint-version, failure-threshold
+- uses: chrysa/github-actions/lint-helm@main
+  with:
+    charts-root: apps
+    helm-repositories: |
+      bjw-s https://bjw-s-labs.github.io/helm-charts
+      traefik https://helm.traefik.io/traefik
+
+- uses: chrysa/github-actions/validate-terraform@main
+  with:
+    working-directory: terraform
+```

--- a/lint-bash/action.yml
+++ b/lint-bash/action.yml
@@ -1,0 +1,28 @@
+description: Run shellcheck and shfmt over the repository's shell scripts
+inputs:
+  exclude-paths:
+    default: ./.git/* ./archive/*
+    description: Space-separated find(1) path patterns to skip
+    required: false
+  indent:
+    default: '4'
+    description: shfmt indentation width
+    required: false
+  severity:
+    default: error
+    description: shellcheck severity threshold
+    required: false
+name: Lint Bash
+runs:
+  steps:
+  - name: Install shellcheck + shfmt
+    run: sudo apt-get install -y shellcheck shfmt
+    shell: bash
+  - env:
+      EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
+      SHELLCHECK_SEVERITY: ${{ inputs.severity }}
+      SHFMT_INDENT: ${{ inputs.indent }}
+    name: shellcheck + shfmt
+    run: bash "${GITHUB_ACTION_PATH}/../scripts/lint_bash.sh"
+    shell: bash
+  using: composite

--- a/lint-docker/action.yml
+++ b/lint-docker/action.yml
@@ -1,0 +1,25 @@
+description: Run hadolint over the repository's Dockerfiles
+inputs:
+  exclude-paths:
+    default: ./.git/* ./archive/*
+    description: Space-separated find(1) path patterns to skip
+    required: false
+  failure-threshold:
+    default: warning
+    description: hadolint failure threshold
+    required: false
+  hadolint-version:
+    default: v2.14.0
+    description: Pinned hadolint release
+    required: false
+name: Lint Dockerfile
+runs:
+  steps:
+  - env:
+      EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
+      FAILURE_THRESHOLD: ${{ inputs.failure-threshold }}
+      HADOLINT_VERSION: ${{ inputs.hadolint-version }}
+    name: hadolint
+    run: bash "${GITHUB_ACTION_PATH}/../scripts/lint_docker.sh"
+    shell: bash
+  using: composite

--- a/lint-helm/action.yml
+++ b/lint-helm/action.yml
@@ -1,0 +1,27 @@
+description: Run helm lint --strict on every chart found under the charts root
+inputs:
+  charts-root:
+    default: apps
+    description: Directory holding the charts (searched at depth 2)
+    required: false
+  helm-repositories:
+    default: ''
+    description: 'Newline-separated "name url" pairs added before linting'
+    required: false
+  helm-version:
+    default: latest
+    description: Helm version to install
+    required: false
+name: Lint Helm Charts
+runs:
+  steps:
+  - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+    with:
+      version: ${{ inputs.helm-version }}
+  - env:
+      CHARTS_ROOT: ${{ inputs.charts-root }}
+      HELM_REPOSITORIES: ${{ inputs.helm-repositories }}
+    name: helm lint
+    run: bash "${GITHUB_ACTION_PATH}/../scripts/lint_helm.sh"
+    shell: bash
+  using: composite

--- a/lint-yaml/action.yml
+++ b/lint-yaml/action.yml
@@ -1,0 +1,36 @@
+description: Run yamllint over the repository's YAML files
+inputs:
+  config-file:
+    default: .yamllint.yaml
+    description: yamllint configuration file
+    required: false
+  exclude-paths:
+    default: ./.git/* ./archive/*
+    description: Space-separated find(1) path patterns to skip
+    required: false
+  python-version:
+    default: '3.12'
+    description: Python version used to install yamllint
+    required: false
+  yamllint-version:
+    default: 1.38.0
+    description: Pinned yamllint version
+    required: false
+name: Lint YAML
+runs:
+  steps:
+  - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+    with:
+      python-version: ${{ inputs.python-version }}
+  - env:
+      YAMLLINT_VERSION: ${{ inputs.yamllint-version }}
+    name: Install yamllint
+    run: 'pip install --only-binary :all: "yamllint==${YAMLLINT_VERSION}"'
+    shell: bash
+  - env:
+      CONFIG_FILE: ${{ inputs.config-file }}
+      EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
+    name: yamllint
+    run: bash "${GITHUB_ACTION_PATH}/../scripts/lint_yaml.sh"
+    shell: bash
+  using: composite

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,29 @@
+# scripts
+
+**Role.** Shell entrypoints for the composite actions in this repo. A step in an
+`action.yml` is a `uses:` or a one-line `run:`; anything longer lives here.
+
+## Structure
+
+| Path              | Purpose                                        |
+| ----------------- | ---------------------------------------------- |
+| `lint_yaml.sh`    | yamllint over the repo's YAML (`lint-yaml`)    |
+| `lint_bash.sh`    | shellcheck + shfmt (`lint-bash`)               |
+| `lint_docker.sh`  | hadolint over Dockerfiles (`lint-docker`)      |
+| `lint_helm.sh`    | `helm lint --strict` per chart (`lint-helm`)   |
+
+## Should contain
+
+- Bash entrypoints called by exactly one composite action, parameterised through
+  environment variables the action declares as `inputs`.
+
+## Should NOT contain
+
+- Python logic — that goes in a package like `notion_sync/`, with tests.
+- Anything a maintained public action already does — reuse it instead.
+
+## Rules
+
+- `set -euo pipefail`, `shellcheck --severity=error` clean, `shfmt -i 4`.
+- Inputs arrive as env vars with a default (`${VAR:-default}`); no positional args.
+- An empty match set exits 0 with a message, never fails the job.

--- a/scripts/lint_bash.sh
+++ b/scripts/lint_bash.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Run shellcheck and shfmt over every shell script, minus the excluded path patterns.
+set -euo pipefail
+
+read -r -a excludes <<<"${EXCLUDE_PATHS:-}"
+find_args=(. -name "*.sh")
+for pattern in "${excludes[@]}"; do
+    find_args+=(-not -path "$pattern")
+done
+
+mapfile -t scripts < <(find "${find_args[@]}")
+if [ ${#scripts[@]} -eq 0 ]; then
+    echo "No shell scripts found, skipping."
+    exit 0
+fi
+
+shellcheck --severity="${SHELLCHECK_SEVERITY:-error}" "${scripts[@]}"
+shfmt -d -i "${SHFMT_INDENT:-4}" "${scripts[@]}" || true

--- a/scripts/lint_bash.sh
+++ b/scripts/lint_bash.sh
@@ -9,7 +9,7 @@ for pattern in "${excludes[@]}"; do
 done
 
 mapfile -t scripts < <(find "${find_args[@]}")
-if [ ${#scripts[@]} -eq 0 ]; then
+if [[ ${#scripts[@]} -eq 0 ]]; then
     echo "No shell scripts found, skipping."
     exit 0
 fi

--- a/scripts/lint_docker.sh
+++ b/scripts/lint_docker.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 version="${HADOLINT_VERSION:-v2.14.0}"
-curl -fsSL "https://github.com/hadolint/hadolint/releases/download/${version}/hadolint-Linux-x86_64" \
+curl --proto "=https" --tlsv1.2 -fsSL "https://github.com/hadolint/hadolint/releases/download/${version}/hadolint-Linux-x86_64" \
     -o /usr/local/bin/hadolint
 chmod +x /usr/local/bin/hadolint
 
@@ -14,7 +14,7 @@ for pattern in "${excludes[@]}"; do
 done
 
 mapfile -t dockerfiles < <(find "${find_args[@]}")
-if [ ${#dockerfiles[@]} -eq 0 ]; then
+if [[ ${#dockerfiles[@]} -eq 0 ]]; then
     echo "No Dockerfiles found, skipping."
     exit 0
 fi

--- a/scripts/lint_docker.sh
+++ b/scripts/lint_docker.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Install hadolint and lint every Dockerfile, minus the excluded path patterns.
+set -euo pipefail
+
+version="${HADOLINT_VERSION:-v2.14.0}"
+curl -fsSL "https://github.com/hadolint/hadolint/releases/download/${version}/hadolint-Linux-x86_64" \
+    -o /usr/local/bin/hadolint
+chmod +x /usr/local/bin/hadolint
+
+read -r -a excludes <<<"${EXCLUDE_PATHS:-}"
+find_args=(. \( -name "Dockerfile" -o -name "*.Dockerfile" \))
+for pattern in "${excludes[@]}"; do
+    find_args+=(-not -path "$pattern")
+done
+
+mapfile -t dockerfiles < <(find "${find_args[@]}")
+if [ ${#dockerfiles[@]} -eq 0 ]; then
+    echo "No Dockerfiles found, skipping."
+    exit 0
+fi
+
+hadolint --failure-threshold "${FAILURE_THRESHOLD:-warning}" "${dockerfiles[@]}"

--- a/scripts/lint_helm.sh
+++ b/scripts/lint_helm.sh
@@ -5,13 +5,13 @@ set -uo pipefail
 charts_root="${CHARTS_ROOT:-apps}"
 
 while read -r name url; do
-    [ -z "${name:-}" ] && continue
+    [[ -z "${name:-}" ]] && continue
     helm repo add "$name" "$url"
 done <<<"${HELM_REPOSITORIES:-}"
-[ -n "${HELM_REPOSITORIES:-}" ] && helm repo update
+[[ -n "${HELM_REPOSITORIES:-}" ]] && helm repo update
 
 mapfile -t charts < <(find "$charts_root" -mindepth 2 -maxdepth 2 -name "Chart.yaml" -printf '%h\n')
-if [ ${#charts[@]} -eq 0 ]; then
+if [[ ${#charts[@]} -eq 0 ]]; then
     echo "No chart found under ${charts_root}, skipping."
     exit 0
 fi

--- a/scripts/lint_helm.sh
+++ b/scripts/lint_helm.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# helm dependency update + helm lint --strict on every chart under the charts root.
+set -uo pipefail
+
+charts_root="${CHARTS_ROOT:-apps}"
+
+while read -r name url; do
+    [ -z "${name:-}" ] && continue
+    helm repo add "$name" "$url"
+done <<<"${HELM_REPOSITORIES:-}"
+[ -n "${HELM_REPOSITORIES:-}" ] && helm repo update
+
+mapfile -t charts < <(find "$charts_root" -mindepth 2 -maxdepth 2 -name "Chart.yaml" -printf '%h\n')
+if [ ${#charts[@]} -eq 0 ]; then
+    echo "No chart found under ${charts_root}, skipping."
+    exit 0
+fi
+
+errors=0
+for chart in "${charts[@]}"; do
+    echo "→ dependency update: $chart"
+    helm dependency update "$chart" >/dev/null 2>&1 || true
+    echo "→ lint: $chart"
+    helm lint "$chart" --strict || errors=$((errors + 1))
+done
+exit "$errors"

--- a/scripts/lint_yaml.sh
+++ b/scripts/lint_yaml.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# yamllint over every YAML file, minus the excluded path patterns.
+set -euo pipefail
+
+config_file="${CONFIG_FILE:-.yamllint.yaml}"
+read -r -a excludes <<<"${EXCLUDE_PATHS:-}"
+
+find_args=(. \( -name "*.yml" -o -name "*.yaml" \))
+for pattern in "${excludes[@]}"; do
+    find_args+=(-not -path "$pattern")
+done
+
+mapfile -t files < <(find "${find_args[@]}")
+if [ ${#files[@]} -eq 0 ]; then
+    echo "No YAML files found, skipping."
+    exit 0
+fi
+
+yamllint --config-file "$config_file" "${files[@]}"

--- a/scripts/lint_yaml.sh
+++ b/scripts/lint_yaml.sh
@@ -11,7 +11,7 @@ for pattern in "${excludes[@]}"; do
 done
 
 mapfile -t files < <(find "${find_args[@]}")
-if [ ${#files[@]} -eq 0 ]; then
+if [[ ${#files[@]} -eq 0 ]]; then
     echo "No YAML files found, skipping."
     exit 0
 fi

--- a/validate-terraform/action.yml
+++ b/validate-terraform/action.yml
@@ -1,0 +1,29 @@
+description: Run terraform init (no backend), validate and fmt check — never applies
+inputs:
+  terraform-version:
+    default: ~1.6
+    description: Terraform version constraint
+    required: false
+  working-directory:
+    default: terraform
+    description: Directory holding the Terraform configuration
+    required: false
+name: Validate Terraform
+runs:
+  steps:
+  - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+    with:
+      terraform_version: ${{ inputs.terraform-version }}
+  - name: terraform init (backend=false, no credentials needed)
+    run: terraform init -backend=false -input=false
+    shell: bash
+    working-directory: ${{ inputs.working-directory }}
+  - name: terraform validate
+    run: terraform validate
+    shell: bash
+    working-directory: ${{ inputs.working-directory }}
+  - name: terraform fmt check
+    run: terraform fmt -check -recursive
+    shell: bash
+    working-directory: ${{ inputs.working-directory }}
+  using: composite


### PR DESCRIPTION
Fleet audit finding: **9 repo-local composite actions**, all in `chrysa/server` — the only repo violating *no `.github/actions/**` in a product repo*.

This PR takes the five that are generic and useful fleet-wide:

| Action | Was | Inputs |
|---|---|---|
| `lint-yaml` | server/.github/actions/lint-yaml | `config-file`, `exclude-paths`, `python-version`, `yamllint-version` |
| `lint-bash` | server/.github/actions/lint-bash | `severity`, `indent`, `exclude-paths` |
| `lint-docker` | server/.github/actions/lint-docker | `hadolint-version`, `failure-threshold`, `exclude-paths` |
| `lint-helm` | server/.github/actions/lint-helm | `charts-root`, `helm-repositories`, `helm-version` |
| `validate-terraform` | server/.github/actions/validate-terraform | `working-directory`, `terraform-version` |

Also applies the rest of the standard while moving them:

- multi-line `run:` bodies (find/mapfile/loops) move out of YAML into `scripts/*.sh`, shellcheck-clean at `--severity=error`, `shfmt -i 4`;
- hardcoded server paths (`apps`, `terraform`, `./archive/`) become inputs with the server values as defaults, so server's call sites stay behaviour-identical;
- `azure/setup-helm` and `hashicorp/setup-terraform` pinned by commit SHA.

`lint-python` is deliberately not extracted — `ruff-check` + `mypy-check` already exist here.

Follow-up PR on `chrysa/server`: swap the five local actions for these and delete `.github/actions/lint-*`, `validate-terraform`. The four service actions (build/deploy/remove-service) stay local for now — they are genuinely server-specific and need their own decision.