### PR TITLE
fix(pre-commit): bashate ignore list is one argument

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,8 +36,7 @@ repos:
   hooks:
   - id: bashate
     args:
-    - --ignore=E006
-    - E020
+    - --ignore=E006,E020
 - repo: https://github.com/chrysa/pre-commit-tools
   rev: v0.2.0-247
   hooks:


### PR DESCRIPTION
The hook was configured as:

```yaml
args:
  - --ignore=E006
  - E020
```

so bashate read `E020` as a **file path** and failed every run:

```
bashate: [Errno 2] No such file or directory: 'E020'
```

`Pre-commit checks` was therefore red on every PR of this repo, including the release promotion #220. Merged into a single `--ignore=E006,E020`.