### PR TITLE
chore(ci): pin third-party actions by commit SHA

### DIFF
--- a/.github/workflows/ci-python-app.yml
+++ b/.github/workflows/ci-python-app.yml
@@ -96,7 +96,7 @@ jobs:
                   python-version: ${{ inputs.latest-python }}
                   extras: ${{ inputs.extras }}
 
-            - uses: pre-commit/action@v3.0.1
+            - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
               with:
                   extra_args: --all-files --hook-stage pre-push
               env:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -112,7 +112,7 @@ jobs:
 
             # Hooks without explicit `stages:` run at all stages; --hook-stage
             # pre-push also covers mypy / regression-gate. One invocation = full surface.
-            - uses: pre-commit/action@v3.0.1
+            - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
               with:
                   extra_args: --all-files --hook-stage pre-push
               env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
               with:
                   python-version: "3.14"
 
-            - uses: pre-commit/action@v3.0.1
+            - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
               env:
                   SKIP: no-commit-to-branch
 
@@ -72,13 +72,13 @@ jobs:
                   fetch-depth: 0
 
             - name: Install GitVersion
-              uses: gittools/actions/gitversion/setup@v4.5.0
+              uses: gittools/actions/gitversion/setup@bc6623af8fc07d5a8903052dd46da33403eec8e8 # v4.5.0
               with:
                   versionSpec: 6.x
 
             - name: Determine version
               id: gitversion
-              uses: gittools/actions/gitversion/execute@v4.5.0
+              uses: gittools/actions/gitversion/execute@bc6623af8fc07d5a8903052dd46da33403eec8e8 # v4.5.0
 
             - name: Debug GitVersion outputs
               run: |
@@ -101,7 +101,7 @@ jobs:
 
             - name: Generate release notes
               if: steps.tag_check.outputs.exists == 'false'
-              uses: orhun/git-cliff-action@v4
+              uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
               with:
                   config: cliff.toml
                   args: --unreleased --tag v${{ steps.gitversion.outputs.majorMinorPatch }} --strip all
@@ -130,7 +130,7 @@ jobs:
 
             - name: Create GitHub Release
               if: steps.tag_check.outputs.exists == 'false'
-              uses: softprops/action-gh-release@v3.0.2
+              uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
               with:
                   tag_name: v${{ steps.gitversion.outputs.majorMinorPatch }}
                   name: v${{ steps.gitversion.outputs.majorMinorPatch }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
         steps:
             - name: Fetch Dependabot metadata
               id: dependabot-metadata
-              uses: dependabot/fetch-metadata@v3
+              uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -17,7 +17,7 @@ jobs:
 
         steps:
             - name: Check dependencies
-              uses: gregsdennis/dependencies-action@main
+              uses: gregsdennis/dependencies-action@a8cccab69814b9b985496cf97cbfe154c96c03c7 # main
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,19 +124,19 @@ jobs:
         steps:
             - uses: actions/checkout@v7.0.1
             - name: Log in to GHCR
-              uses: docker/login-action@v4.5.1
+              uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
-            - uses: docker/setup-buildx-action@v4
+            - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
             - name: Resolve version
               id: version
               run: echo "value=${{ github.event.release.tag_name || inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
               shell: bash
             - name: Metadata
               id: meta
-              uses: docker/metadata-action@v6
+              uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
               with:
                   images: ${{ inputs.image-base }}
                   tags: |
@@ -144,7 +144,7 @@ jobs:
                       type=raw,value=${{ steps.version.outputs.value }}
                       type=sha,prefix=sha-
             - name: Build and push
-              uses: docker/build-push-action@v7.3.0
+              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
               with:
                   context: ${{ inputs.backend-context }}
                   file: ${{ inputs.backend-dockerfile }}
@@ -164,19 +164,19 @@ jobs:
         steps:
             - uses: actions/checkout@v7.0.1
             - name: Log in to GHCR
-              uses: docker/login-action@v4.5.1
+              uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
-            - uses: docker/setup-buildx-action@v4
+            - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
             - name: Resolve version
               id: version
               run: echo "value=${{ github.event.release.tag_name || inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
               shell: bash
             - name: Metadata
               id: meta
-              uses: docker/metadata-action@v6
+              uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
               with:
                   images: ${{ inputs.frontend-image }}
                   tags: |
@@ -184,7 +184,7 @@ jobs:
                       type=raw,value=${{ steps.version.outputs.value }}
                       type=sha,prefix=sha-
             - name: Build and push
-              uses: docker/build-push-action@v7.3.0
+              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
               with:
                   context: ${{ inputs.frontend-context }}
                   file: ${{ inputs.frontend-dockerfile }}

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -39,7 +39,7 @@ jobs:
             # Replay every pre-commit hook, including pre-push-staged ones (mypy).
             # Hooks without an explicit `stages:` (ruff, ruff-format) run at all
             # stages, so a single invocation covers the full lint surface.
-            - uses: pre-commit/action@v3.0.1
+            - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
               with:
                   extra_args: --all-files --hook-stage pre-push
               env:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
               run: mkdocs build
 
             - name: Deploy to GitHub Pages
-              uses: peaceiris/actions-gh-pages@v4.1.0
+              uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   publish_dir: site

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      uses: gregsdennis/dependencies-action@v1.4.2
+      uses: gregsdennis/dependencies-action@a8cccab69814b9b985496cf97cbfe154c96c03c7 # v1.4.2
     - uses: Levi-Lesches/blocking-issues@2eeffdc6b055341f635eb0f3e4aea671516a61dc
       with:
         use-label: Blocked

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,6 +21,6 @@ jobs:
             - uses: actions/setup-python@v7.0.0
               with:
                   python-version: '3.14'
-            - uses: pre-commit/action@v3.0.1
+            - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
               env:
                   SKIP: no-commit-to-branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,16 +23,16 @@ jobs:
                   token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
             - name: Setup GitVersion
-              uses: gittools/actions/gitversion/setup@v4
+              uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4
               with:
                   versionSpec: 6.x
 
             - name: Determine version
               id: gitversion
-              uses: gittools/actions/gitversion/execute@v4
+              uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4
 
             - name: Install git-cliff
-              uses: taiki-e/install-action@git-cliff
+              uses: taiki-e/install-action@e215f18e24d7f4b411833009234c054235f9447f # git-cliff
 
             - name: Generate changelog
               id: changelog
@@ -50,7 +50,7 @@ jobs:
                   git push origin "${{ steps.changelog.outputs.version }}" || echo "Tag push skipped"
 
             - name: Create GitHub Release
-              uses: softprops/action-gh-release@v3.0.2
+              uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
               with:
                   tag_name: ${{ steps.changelog.outputs.version }}
                   name: Release ${{ steps.changelog.outputs.version }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -19,6 +19,6 @@ jobs:
             - uses: actions/checkout@v7.0.1
               with:
                   fetch-depth: 0
-            - uses: gitleaks/gitleaks-action@v3.0.0
+            - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -40,7 +40,7 @@ jobs:
             - name: Run tests with coverage
               run: pytest --cov=notion_sync --cov-report=xml:coverage.xml
             - name: SonarCloud scan
-              uses: SonarSource/sonarqube-scan-action@v8.2.1
+              uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
               with:
                   args: >
                       -Dsonar.projectKey=chrysa_github-actions


### PR DESCRIPTION
Applies the fleet GitHub Actions standard: **third-party actions are pinned by commit
SHA**, with the version kept in a trailing comment. `actions/*` and `chrysa/*` stay on tags.

A mutable tag or branch means the code executing in CI — with the workflow token — can change
under you without a diff. Found by a fleet-wide audit (87 unpinned references across 63 repos);
the copies distributed from `shared-standards` were fixed at the source in shared-standards#289,
this PR covers the workflows this repo owns.

Pinned here:

- `SonarSource/sonarqube-scan-action` `v8.2.1` → `22918119ff8e`
- `dependabot/fetch-metadata` `v3` → `25dd0e34f4fe`
- `docker/build-push-action` `v7.3.0` → `53b7df96c91f`
- `docker/login-action` `v4.5.1` → `abd2ef45e78c`
- `docker/metadata-action` `v6` → `dc8028041006`
- `docker/setup-buildx-action` `v4` → `bb05f3f5519d`
- `gitleaks/gitleaks-action` `v3.0.0` → `e0c47f4f8be3`
- `gittools/actions/gitversion/execute` `v4.5.0` → `bc6623af8fc0`
- `gittools/actions/gitversion/execute` `v4` → `7417b1089e2c`
- `gittools/actions/gitversion/setup` `v4.5.0` → `bc6623af8fc0`
- `gittools/actions/gitversion/setup` `v4` → `7417b1089e2c`
- `gregsdennis/dependencies-action` `main` → `a8cccab69814`
- `gregsdennis/dependencies-action` `v1.4.2` → `a8cccab69814`
- `orhun/git-cliff-action` `v4` → `f50e11560dce`
- `peaceiris/actions-gh-pages` `v4.1.0` → `84c30a85c199`
- `pre-commit/action` `v3.0.1` → `2c7b3805fd2a`
- `softprops/action-gh-release` `v3.0.2` → `3d0d9888cb7f`
- `taiki-e/install-action` `git-cliff` → `e215f18e24d7`
