### PR TITLE
feat(policy): add the check-branch-policy composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Shared composite GitHub Actions for `chrysa/*` repositories.
 | `chrysa/github-actions/lint-docker@main` | hadolint over Dockerfiles |
 | `chrysa/github-actions/lint-helm@main` | `helm lint --strict` per chart |
 | `chrysa/github-actions/validate-terraform@main` | terraform init/validate/fmt (never applies) |
+| `chrysa/github-actions/check-branch-policy@main` | Enforce the chrysa branch model on a PR |
 
 ## Usage
 
@@ -311,4 +312,14 @@ composite actions. Every path/version is an input, so any repo can consume them.
 - uses: chrysa/github-actions/validate-terraform@main
   with:
     working-directory: terraform
+```
+
+### check-branch-policy
+
+Enforce the branch model on a pull request: `develop -> main` is the release promotion,
+`hotfix/*` is the only other branch allowed to target `main`, everything else must match
+`type/short-description` and integrate through `develop`.
+
+```yaml
+- uses: chrysa/github-actions/check-branch-policy@main
 ```

--- a/check-branch-policy/action.yml
+++ b/check-branch-policy/action.yml
@@ -1,0 +1,26 @@
+description: Enforce the chrysa branch model on a pull request (develop is the integration
+  branch; only a release promotion or a hotfix may target main)
+inputs:
+  base-ref:
+    default: ${{ github.base_ref }}
+    description: Branch the pull request targets
+    required: false
+  branch-pattern:
+    default: ^(feat|feature|fix|chore|docs|refactor|test|ci|build|perf|hotfix)/[a-z0-9._-]+$
+    description: Regex every source branch must match
+    required: false
+  head-ref:
+    default: ${{ github.head_ref }}
+    description: Source branch of the pull request
+    required: false
+name: Check branch policy
+runs:
+  steps:
+  - env:
+      BASE_NAME: ${{ inputs.base-ref }}
+      BRANCH_NAME: ${{ inputs.head-ref }}
+      BRANCH_PATTERN: ${{ inputs.branch-pattern }}
+    name: Validate PR source branch
+    run: bash "${GITHUB_ACTION_PATH}/../scripts/check_branch_policy.sh"
+    shell: bash
+  using: composite

--- a/scripts/check_branch_policy.sh
+++ b/scripts/check_branch_policy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Enforce the chrysa branch model on a pull request.
+#
+#   develop -> main   release promotion, always allowed
+#   hotfix/* -> main  the only other branch allowed to target main
+#   type/slug -> *    every other PR, integrated through develop
+#
+# Inputs: BRANCH_NAME (head ref), BASE_NAME (base ref), BRANCH_PATTERN (optional).
+set -euo pipefail
+
+pattern="${BRANCH_PATTERN:-^(feat|feature|fix|chore|docs|refactor|test|ci|build|perf|hotfix)/[a-z0-9._-]+$}"
+
+if [[ "$BASE_NAME" == "main" && "$BRANCH_NAME" == "develop" ]]; then
+    echo "Release promotion develop -> main: allowed"
+    exit 0
+fi
+
+if [[ ! "$BRANCH_NAME" =~ $pattern ]]; then
+    echo "::error::Invalid branch name: $BRANCH_NAME"
+    echo "Expected: type/short-description (e.g. feat/add-auth-flow)"
+    exit 1
+fi
+
+if [[ "$BASE_NAME" == "main" && ! "$BRANCH_NAME" =~ ^hotfix/ ]]; then
+    echo "::error::PR targets main from '$BRANCH_NAME'."
+    echo "Only a release PR from develop, or a hotfix/* branch, may target main."
+    exit 1
+fi
+
+echo "Branch policy satisfied: $BRANCH_NAME -> $BASE_NAME"


### PR DESCRIPTION
The branch-model gate was a 21-line `run:` block inside `shared-standards/.github/workflows/enforce-feature-branch.yml` — over the standard's limit, and duplicated into the distributed template so every repo carries its own copy of the logic.

It becomes `check-branch-policy`, with the rules in `scripts/check_branch_policy.sh`:

- `develop -> main` — release promotion, always allowed;
- `hotfix/* -> main` — the only other branch that may target main;
- anything else must match `type/short-description` and integrate through develop.

Pattern overridable via the `branch-pattern` input. Shellcheck-clean, smoke-tested on the four cases (promotion, valid feature, feature targeting main, malformed name).

This gate matters: it is exactly what would have caught a batch of PRs opened against `main` earlier today — the org-wide Actions outage meant nothing enforced it.