### PR TITLE
ci: pin chrysa/github-actions at v1.6.0

### DIFF
--- a/.github/workflows/ci-fullstack.yml
+++ b/.github/workflows/ci-fullstack.yml
@@ -11,7 +11,7 @@
 # Caller (repo/.github/workflows/ci.yml):
 #   jobs:
 #     ci:
-#       uses: chrysa/github-actions/.github/workflows/ci-fullstack.yml@main
+#       uses: chrysa/github-actions/.github/workflows/ci-fullstack.yml@v1.6.0
 #       with:
 #         project-key: chrysa_my-monorepo
 #         project-name: my-monorepo
@@ -138,7 +138,7 @@ jobs:
               with:
                   fetch-depth: 0
             - name: SonarCloud scan
-              uses: chrysa/github-actions/sonar-scan-python@v1.4.4
+              uses: chrysa/github-actions/sonar-scan-python@v1.6.0
               with:
                   python-version: ${{ inputs.python-version }}
                   sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci-python-app.yml
+++ b/.github/workflows/ci-python-app.yml
@@ -10,7 +10,7 @@
 # Caller (repo/.github/workflows/ci.yml):
 #   jobs:
 #     ci:
-#       uses: chrysa/github-actions/.github/workflows/ci-python-app.yml@main
+#       uses: chrysa/github-actions/.github/workflows/ci-python-app.yml@v1.6.0
 #       with:
 #         sources: "app tests"
 #         typecheck-paths: app
@@ -91,7 +91,7 @@ jobs:
             - uses: actions/checkout@v7.0.1
 
             - name: Setup environment
-              uses: chrysa/github-actions/tool-setup@v1.4.4
+              uses: chrysa/github-actions/tool-setup@v1.6.0
               with:
                   python-version: ${{ inputs.latest-python }}
                   extras: ${{ inputs.extras }}
@@ -112,13 +112,13 @@ jobs:
             - uses: actions/checkout@v7.0.1
 
             - name: Setup environment
-              uses: chrysa/github-actions/tool-setup@v1.4.4
+              uses: chrysa/github-actions/tool-setup@v1.6.0
               with:
                   python-version: ${{ inputs.latest-python }}
                   extras: ${{ inputs.extras }}
 
             - name: Ruff checks
-              uses: chrysa/github-actions/ruff-check@v1.4.4
+              uses: chrysa/github-actions/ruff-check@v1.6.0
               with:
                   python-version: ${{ inputs.latest-python }}
                   latest-python: ${{ inputs.latest-python }}
@@ -183,7 +183,7 @@ jobs:
                   fetch-depth: 0
 
             - name: SonarCloud scan
-              uses: chrysa/github-actions/sonar-scan-python@v1.4.4
+              uses: chrysa/github-actions/sonar-scan-python@v1.6.0
               with:
                   python-version: ${{ inputs.latest-python }}
                   sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -10,7 +10,7 @@
 # Caller (repo/.github/workflows/ci.yml):
 #   jobs:
 #     ci:
-#       uses: chrysa/github-actions/.github/workflows/ci-python.yml@v1.1.3
+#       uses: chrysa/github-actions/.github/workflows/ci-python.yml@v1.6.0
 #       with:
 #         package: fastapi_app_generator
 #         sources: "src/fastapi_app_generator tests"
@@ -105,7 +105,7 @@ jobs:
             - uses: actions/checkout@v7.0.1
 
             - name: Setup environment
-              uses: chrysa/github-actions/tool-setup@v1.4.4
+              uses: chrysa/github-actions/tool-setup@v1.6.0
               with:
                   python-version: ${{ inputs.latest-python }}
                   extras: ${{ inputs.extras }}
@@ -128,14 +128,14 @@ jobs:
             - uses: actions/checkout@v7.0.1
 
             - name: Setup environment
-              uses: chrysa/github-actions/tool-setup@v1.4.4
+              uses: chrysa/github-actions/tool-setup@v1.6.0
               with:
                   python-version: ${{ inputs.latest-python }}
                   extras: ${{ inputs.extras }}
 
             # Uploads the `ruff-report` artifact consumed by sonar-scan-python.
             - name: Ruff checks
-              uses: chrysa/github-actions/ruff-check@v1.4.4
+              uses: chrysa/github-actions/ruff-check@v1.6.0
               with:
                   python-version: ${{ inputs.latest-python }}
                   latest-python: ${{ inputs.latest-python }}
@@ -170,14 +170,14 @@ jobs:
             - uses: actions/checkout@v7.0.1
 
             - name: Setup environment
-              uses: chrysa/github-actions/tool-setup@v1.4.4
+              uses: chrysa/github-actions/tool-setup@v1.6.0
               with:
                   python-version: ${{ matrix.python-version }}
                   extras: ${{ inputs.extras }}
 
             # Uploads `test-results-<py>` (coverage.xml + junit.xml).
             - name: Run tests
-              uses: chrysa/github-actions/run-tests@v1.4.4
+              uses: chrysa/github-actions/run-tests@v1.6.0
               with:
                   cov-module: ${{ inputs.package }}
                   cov-fail-under: ${{ inputs.cov-fail-under }}
@@ -201,7 +201,7 @@ jobs:
             # Downloads test-results-<latest> (coverage + junit), ruff-report,
             # mypy-report, then runs the scan. Needs the project + SONAR_TOKEN.
             - name: SonarCloud scan
-              uses: chrysa/github-actions/sonar-scan-python@v1.4.4
+              uses: chrysa/github-actions/sonar-scan-python@v1.6.0
               with:
                   python-version: ${{ inputs.latest-python }}
                   sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         steps:
             - uses: actions/checkout@v7.0.1
 
-            - uses: chrysa/github-actions/python-setup@v1.4.4
+            - uses: chrysa/github-actions/python-setup@v1.6.0
               with:
                   python-version: "3.14"
 
@@ -48,7 +48,7 @@ jobs:
         steps:
             - uses: actions/checkout@v7.0.1
 
-            - uses: chrysa/github-actions/python-setup@v1.4.4
+            - uses: chrysa/github-actions/python-setup@v1.6.0
               with:
                   python-version: "3.14"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@
 #     workflow_dispatch: { inputs: { tag: { required: true } } }
 #   jobs:
 #     deploy:
-#       uses: chrysa/github-actions/.github/workflows/deploy.yml@main
+#       uses: chrysa/github-actions/.github/workflows/deploy.yml@v1.6.0
 #       with:
 #         image-base: ghcr.io/chrysa/my-app
 #         backend-context: backend            # '.' for single-package repos

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -31,7 +31,7 @@ jobs:
             # tool-setup = python-setup + install-project[extras]; ensures mypy
             # (language: system) and its stubs/deps are available for the replay.
             - name: Setup environment
-              uses: chrysa/github-actions/tool-setup@v1.4.4
+              uses: chrysa/github-actions/tool-setup@v1.6.0
               with:
                   python-version: ${{ inputs.python-version }}
                   extras: ${{ inputs.extras }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -32,7 +32,7 @@ jobs:
               uses: actions/checkout@v7.0.1
               with:
                   fetch-depth: 0
-            - uses: chrysa/github-actions/python-setup@05f91eb1fc78ffad759e1ca904161b4875f466a5 # v1.4.4
+            - uses: chrysa/github-actions/python-setup@v1.6.0 # v1.4.4
               with:
                   python-version: "3.14"
             - name: Install test dependencies


### PR DESCRIPTION
Moves every `chrysa/github-actions` pin to **v1.6.0**.

An older tag keeps running an older gate. `v1.4.x` of `quality-gate-check.yml` invokes `make quality-gate-verify` with no guard and fails with `No rule to make target` on any repo that is not onboarded — a red check that says nothing about the code. `v1.6.0` also skips `pip install -e .` for a tooling-only `pyproject.toml` and only enables the npm cache when a lockfile exists.

Swept from `chrysa/shared-standards` (`scripts/github_actions_pin.py`).