### PR TITLE
ci: concurrency group and job timeouts (annexe CI-030, CI-031)

### DIFF
--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -11,10 +11,15 @@
     paths:
     - .github/workflows/**
   workflow_call: null
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   actionlint:
     name: Lint workflows
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/approved-label.yml
+++ b/.github/workflows/approved-label.yml
@@ -8,6 +8,7 @@ jobs:
   label-when-approved:
     name: Label when approved
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Label when approved by committers
       uses: TobKed/label-when-approved-action@0058d0094da27e116fad6e0da516ebe1107f26de

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -5,9 +5,14 @@
     - ready_for_review
     - reopened
   workflow_call: null
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   add-reviews:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/auto-update-pre-commit.yml
+++ b/.github/workflows/auto-update-pre-commit.yml
@@ -7,6 +7,7 @@ jobs:
   pre-commit-autoupdate:
     name: Bump pre-commit hooks
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
     auto-merge:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         if: github.actor == 'dependabot[bot]'
         steps:
             - name: Fetch Dependabot metadata

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -10,9 +10,14 @@ permissions:
     issues: write
     pull-requests: write
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     check_dependencies:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         name: Check PR dependencies
 
         steps:

--- a/.github/workflows/enforce-feature-branch.yml
+++ b/.github/workflows/enforce-feature-branch.yml
@@ -11,6 +11,7 @@ jobs:
     branch-policy:
         if: github.actor != 'dependabot[bot]'
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         steps:
             - name: Validate PR source branch naming
               shell: bash

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,10 +2,15 @@
   pull_request: null
   workflow_call: null
   workflow_dispatch: null
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   labels:
     name: Apply labels on pull request
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Get Code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,6 +26,7 @@ jobs:
   mutation:
     name: Mutmut
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7.0.1
 

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -14,10 +14,15 @@
   - cron: 0 0 * * *
   workflow_call: null
   workflow_dispatch: null
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   check_dependencies:
     name: Check Dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request-size.yml
+++ b/.github/workflows/pull-request-size.yml
@@ -1,9 +1,14 @@
 "on":
   pull_request_target: null
   workflow_call: null
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   size-label:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -17,6 +17,7 @@ jobs:
   quality-gate:
     name: No-Regression Quality Gates
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
     release:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         name: Create release
         steps:
             - uses: actions/checkout@v7.0.1

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -12,6 +12,7 @@ jobs:
     gitleaks:
         name: Detect secrets (Gitleaks)
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         permissions:
             contents: read
             pull-requests: read

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -14,6 +14,7 @@ jobs:
   sync-labels:
     name: Synchronize labels
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/update-pr-body.yml
+++ b/.github/workflows/update-pr-body.yml
@@ -3,11 +3,16 @@
     types:
     - opened
     - synchronize
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   update-body:
     if: contains(github.event.pull_request.body, '<!-- auto-changes-start -->')
     name: Fill auto-changes section
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1


### PR DESCRIPTION
Applies the two deterministic rules of annexe [`CI-CD.md`](https://github.com/chrysa/shared-standards/blob/main/standards/annexes/CI-CD.md):

- **CI-030** — every job declares `timeout-minutes:` (set to 30, raise it where the job legitimately runs longer). Without it a hung job holds a runner until the platform cap.
- **CI-031** — every PR-triggered workflow declares a concurrency group. Superseded PR runs are cancelled; **deploy and release workflows queue instead** (`cancel-in-progress: false`) — cancelling a deployment mid-flight is worse than queueing it.

The remaining findings (permissions, `secrets: inherit`, action pinning) are judgement calls and are reported by `scripts/ci_annexe_audit.py`, never guessed.