### PR TITLE
feat(gist): add the gist-publish composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Shared composite GitHub Actions for `chrysa/*` repositories.
 | `chrysa/github-actions/lint-helm@main` | `helm lint --strict` per chart |
 | `chrysa/github-actions/validate-terraform@main` | terraform init/validate/fmt (never applies) |
 | `chrysa/github-actions/check-branch-policy@main` | Enforce the chrysa branch model on a PR |
+| `chrysa/github-actions/gist-publish@main` | Version, changelog and publish the multi-machine setup gist |
 
 ## Usage
 
@@ -322,4 +323,18 @@ Enforce the branch model on a pull request: `develop -> main` is the release pro
 
 ```yaml
 - uses: chrysa/github-actions/check-branch-policy@main
+```
+
+### gist-publish
+
+Bump `SETUP_VERSION`, write the changelog entry, tag, and push the multi-machine setup
+files to the private gist. Extracted from a 149-line workflow duplicated byte-identically
+in `chrysa-skills` and `claude-config`.
+
+```yaml
+- uses: chrysa/github-actions/gist-publish@main
+  with:
+    gist-token: ${{ secrets.GH_PAT_GIST }}
+    gist-id: ${{ secrets.CHRYSA_SETUP_GIST_ID }}
+    bump: ${{ github.event.inputs.bump }}
 ```

--- a/gist-publish/action.yml
+++ b/gist-publish/action.yml
@@ -1,0 +1,55 @@
+description: Bump the multi-machine setup version, write its changelog, tag it and push
+  the files to the private gist
+inputs:
+  bump:
+    default: ''
+    description: Force a bump kind (patch|minor|major); empty derives it from the commit subject
+    required: false
+  gist-dir:
+    default: docs/multi-machine-setup/gist
+    description: Directory holding the files published to the gist
+    required: false
+  gist-id:
+    default: ''
+    description: Target gist id; empty skips the publish with a warning
+    required: false
+  gist-token:
+    description: Token with the gist scope
+    required: true
+  watch-dir:
+    default: docs/multi-machine-setup
+    description: Directory whose commits feed the changelog entry
+    required: false
+name: Publish the multi-machine setup gist
+outputs:
+  version:
+    description: The version that was published
+    value: ${{ steps.version.outputs.next }}
+runs:
+  steps:
+  - env:
+      BUMP_OVERRIDE: ${{ inputs.bump }}
+      GIST_DIR: ${{ inputs.gist-dir }}
+    id: version
+    name: Compute and write the next version
+    run: |
+      COMMIT_SUBJECT="$(git log -1 --pretty=%s)" bash "${GITHUB_ACTION_PATH}/../scripts/gist_bump_version.sh"
+    shell: bash
+  - env:
+      ENTRY_DATE: ${{ github.event.repository.updated_at }}
+      GIST_DIR: ${{ inputs.gist-dir }}
+      NEW_VERSION: ${{ steps.version.outputs.next }}
+      WATCH_DIR: ${{ inputs.watch-dir }}
+    name: Generate the changelog entry
+    run: ENTRY_DATE="$(date +%Y-%m-%d)" bash "${GITHUB_ACTION_PATH}/../scripts/gist_changelog.sh"
+    shell: bash
+  - env:
+      GH_TOKEN: ${{ inputs.gist-token }}
+      GIST_DIR: ${{ inputs.gist-dir }}
+      GIST_ID: ${{ inputs.gist-id }}
+      NEW_VERSION: ${{ steps.version.outputs.next }}
+      WATCH_DIR: ${{ inputs.watch-dir }}
+    name: Commit, tag and publish
+    run: bash "${GITHUB_ACTION_PATH}/../scripts/gist_publish.sh"
+    shell: bash
+  using: composite

--- a/scripts/gist_bump_version.sh
+++ b/scripts/gist_bump_version.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Compute the next SETUP_VERSION for the multi-machine setup gist and write it to the
+# version-carrying scripts. Emits `current` and `next` to $GITHUB_OUTPUT.
+#
+# Inputs: GIST_DIR, BUMP_OVERRIDE (patch|minor|major, optional), COMMIT_SUBJECT.
+set -euo pipefail
+
+gist_dir="${GIST_DIR:-docs/multi-machine-setup/gist}"
+
+kind="patch"
+if [[ "${COMMIT_SUBJECT:-}" =~ BREAKING\ CHANGE|! ]]; then
+    kind="major"
+elif [[ "${COMMIT_SUBJECT:-}" =~ ^feat\( ]]; then
+    kind="minor"
+fi
+[[ -n "${BUMP_OVERRIDE:-}" ]] && kind="$BUMP_OVERRIDE"
+
+current="$(grep -m1 '^SETUP_VERSION=' "$gist_dir/setup-linux.sh" | sed -E 's/.*"([^"]+)".*/\1/')"
+IFS='.' read -r major minor patch <<<"$current"
+case "$kind" in
+    major) major=$((major + 1)); minor=0; patch=0 ;;
+    minor) minor=$((minor + 1)); patch=0 ;;
+    patch) patch=$((patch + 1)) ;;
+    *) echo "::error::unknown bump kind: $kind"; exit 1 ;;
+esac
+next="${major}.${minor}.${patch}"
+
+sed -i -E "s/^SETUP_VERSION=\"[^\"]+\"/SETUP_VERSION=\"${next}\"/" "$gist_dir/setup-linux.sh"
+sed -i -E "s/^\\\$SetupVersion = '[^']+'/\$SetupVersion = '${next}'/" "$gist_dir/setup-windows.ps1"
+
+{
+    echo "current=$current"
+    echo "next=$next"
+} >>"$GITHUB_OUTPUT"
+echo "Bumping $current → $next ($kind)"

--- a/scripts/gist_changelog.sh
+++ b/scripts/gist_changelog.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Prepend a Keep a Changelog entry for the new version, built from the commits touching
+# the watched directory since the previous setup-v* tag.
+# Inputs: GIST_DIR, WATCH_DIR, NEW_VERSION, ENTRY_DATE.
+set -euo pipefail
+
+gist_dir="${GIST_DIR:-docs/multi-machine-setup/gist}"
+watch_dir="${WATCH_DIR:-docs/multi-machine-setup}"
+changelog="$gist_dir/CHANGELOG.md"
+previous_tag="$(git tag --list 'setup-v*' --sort=-v:refname | head -1)"
+range="${previous_tag:+${previous_tag}..}HEAD"
+
+entry="$(mktemp)"
+{
+    echo "## [${NEW_VERSION}] - ${ENTRY_DATE}"
+    echo ""
+    git log --pretty='- %s (%h)' "$range" -- "$watch_dir" | head -30
+    echo ""
+} >"$entry"
+
+if [[ ! -f "$changelog" ]]; then
+    {
+        echo "# Changelog · multi-machine setup"
+        echo ""
+        echo "All notable changes follow [Keep a Changelog](https://keepachangelog.com)."
+        echo ""
+    } >"$changelog"
+fi
+
+merged="$(mktemp)"
+head -4 "$changelog" >"$merged"
+cat "$entry" >>"$merged"
+tail -n +5 "$changelog" >>"$merged"
+mv "$merged" "$changelog"

--- a/scripts/gist_publish.sh
+++ b/scripts/gist_publish.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Commit the version bump, tag it, and push the gist files.
+# Inputs: WATCH_DIR, GIST_DIR, NEW_VERSION, GIST_ID (optional), GH_TOKEN.
+set -euo pipefail
+
+watch_dir="${WATCH_DIR:-docs/multi-machine-setup}"
+gist_dir="${GIST_DIR:-docs/multi-machine-setup/gist}"
+
+git config user.name 'chrysa-bot'
+git config user.email 'bot@chrysa.dev'
+git add "$watch_dir"
+if ! git commit -m "chore(setup): bump v${NEW_VERSION}"; then
+    echo "Nothing to commit — skipping publish."
+    exit 0
+fi
+git tag "setup-v${NEW_VERSION}"
+git push origin HEAD --tags
+
+if [[ -z "${GIST_ID:-}" ]]; then
+    echo "::warning::gist id absent · skip gist publish"
+    exit 0
+fi
+
+cd "$gist_dir"
+gh gist edit "$GIST_ID" \
+    --add setup-linux.sh \
+    --add setup-windows.ps1 \
+    --add README.md \
+    --add CHANGELOG.md
+echo "Gist updated · v${NEW_VERSION}"


### PR DESCRIPTION
`setup-gist-publish.yml` is **149 lines duplicated byte-identically** in `chrysa-skills` and `claude-config` (verified with `diff`), carrying two `run:` blocks over 30 lines. Per the standard, the second occurrence in the fleet is an extraction order.

- `scripts/gist_bump_version.sh` — derive the bump kind from the commit subject (or an explicit override), compute the semver, write it into `setup-linux.sh` and `setup-windows.ps1`;
- `scripts/gist_changelog.sh` — Keep a Changelog entry from the commits since the last `setup-v*` tag;
- `scripts/gist_publish.sh` — commit, tag, push, then `gh gist edit` (warns and skips when no gist id).

All paths are inputs, so the action is not bound to .

**Security fix carried along**: the original bodies interpolated `${{ steps.*.outputs.* }}` and `${{ github.event.inputs.bump }}` **inside the shell script**, which is a script-injection surface. They are now passed as `env:` and read as shell variables.

Follow-up: point both repos at this action and delete their copies.