### PR TITLE
feat: add publish-node-package action (GHCR npm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Shared composite GitHub Actions for `chrysa/*` repositories.
 | `chrysa/github-actions/sonar-scan-node@main` | SonarCloud scan (Node.js / TypeScript) |
 | `chrysa/github-actions/sonar-js-scan@main` | SonarCloud scan (JS / Google Apps Script) |
 | `chrysa/github-actions/publish-python-package@main` | Build + publish Python package to PyPI |
+| `chrysa/github-actions/publish-node-package@main` | Build + publish a scoped npm package to GitHub Packages (private GHCR npm) |
 | `chrysa/github-actions/notion-branch-sync@main` | Sync the pushed branch to the Notion Branch Activity database |
 | `chrysa/github-actions/notion-roadmap-sync@main` | Sync an issue/PR event to the Notion roadmap row |
 | `chrysa/github-actions/lint-yaml@main` | yamllint over the repo's YAML |
@@ -257,6 +258,29 @@ Build and publish a Python package to PyPI.
     build-backend: 'hatch'
     repository-url: 'https://test.pypi.org/legacy/'
 ```
+
+### publish-node-package
+
+Build and publish a scoped npm package to **GitHub Packages** (the private GHCR npm
+registry, `https://npm.pkg.github.com`). The package selects the registry via its own
+`publishConfig.registry`; auth uses the workflow `GITHUB_TOKEN` (never a plaintext PAT),
+and the job needs `permissions: { packages: write }`.
+
+```yaml
+- uses: chrysa/github-actions/publish-node-package@main
+  with:
+    package-dir: packages/typescript/ui
+    node-auth-token: ${{ secrets.GITHUB_TOKEN }}
+
+# Override the Node version or scope
+- uses: chrysa/github-actions/publish-node-package@main
+  with:
+    package-dir: packages/typescript/api-client
+    node-auth-token: ${{ secrets.GITHUB_TOKEN }}
+    node-version: '22'
+    scope: '@chrysa'
+```
+
 
 ### notion-branch-sync
 

--- a/publish-node-package/action.yml
+++ b/publish-node-package/action.yml
@@ -31,14 +31,24 @@ runs:
     run: npm run build --if-present
     shell: bash
     working-directory: ${{ inputs.package-dir }}
-  - name: Publish to GitHub Packages
+  - name: Publish to GitHub Packages (idempotent)
     # publishConfig.registry in the package's package.json selects the GHCR npm
     # registry; setup-node writes the matching .npmrc with the auth token env var.
-    # A re-publish of an already-published version fails with 409 — the caller
-    # gates on a version bump (GitVersion), so a run only reaches here on a new one.
+    # Package versions are set by hand in package.json (decoupled from the repo's
+    # GitVersion tag), so a release re-run would otherwise 409 on an unchanged
+    # version. Skip when this name@version is already published — publish only the
+    # genuinely new ones, making the step safe to run on every release.
     env:
       NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
-    run: npm publish
+    run: |
+      name=$(node -p "require('./package.json').name")
+      version=$(node -p "require('./package.json').version")
+      if npm view "${name}@${version}" version >/dev/null 2>&1; then
+        echo "${name}@${version} is already published — skipping."
+      else
+        echo "Publishing ${name}@${version}…"
+        npm publish
+      fi
     shell: bash
     working-directory: ${{ inputs.package-dir }}
   using: composite

--- a/publish-node-package/action.yml
+++ b/publish-node-package/action.yml
@@ -1,0 +1,44 @@
+description: Build and publish a scoped npm package to GitHub Packages (the private GHCR npm registry)
+inputs:
+  node-auth-token:
+    description: Token with packages:write scope — pass the workflow GITHUB_TOKEN, never a plaintext PAT
+    required: true
+  node-version:
+    default: '22'
+    description: Node.js version for the build environment
+    required: false
+  package-dir:
+    description: Path to the package directory that holds package.json (e.g. packages/typescript/ui)
+    required: true
+  scope:
+    default: '@chrysa'
+    description: npm scope the package publishes under
+    required: false
+name: Publish Node package
+runs:
+  steps:
+  - name: Set up Node.js
+    uses: actions/setup-node@v4
+    with:
+      node-version: ${{ inputs.node-version }}
+      registry-url: https://npm.pkg.github.com
+      scope: ${{ inputs.scope }}
+  - name: Install dependencies
+    run: npm install --no-audit --no-fund
+    shell: bash
+    working-directory: ${{ inputs.package-dir }}
+  - name: Build (if a build script is present)
+    run: npm run build --if-present
+    shell: bash
+    working-directory: ${{ inputs.package-dir }}
+  - name: Publish to GitHub Packages
+    # publishConfig.registry in the package's package.json selects the GHCR npm
+    # registry; setup-node writes the matching .npmrc with the auth token env var.
+    # A re-publish of an already-published version fails with 409 — the caller
+    # gates on a version bump (GitVersion), so a run only reaches here on a new one.
+    env:
+      NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+    run: npm publish
+    shell: bash
+    working-directory: ${{ inputs.package-dir }}
+  using: composite


### PR DESCRIPTION
## Why
`@chrysa/ui` and `@chrysa/api-client` declare `publishConfig` for GitHub Packages but nothing publishes them — chrysa-lib's `release.yml` only tags + creates a GitHub release. Every consumer needs the same publish logic, so it belongs here (dedup), not as a per-repo workflow.

## What
A composite action `publish-node-package`:
- `setup-node` against `https://npm.pkg.github.com` with scope `@chrysa`;
- `npm install` + `npm run build --if-present` in `package-dir`;
- `npm publish` with `NODE_AUTH_TOKEN` = the workflow `GITHUB_TOKEN` (no PAT).

Inputs: `package-dir` (required), `node-auth-token` (required), `node-version` (default 22), `scope` (default @chrysa). README documents usage.

## Next (follow-up PR on chrysa-lib)
Add a publish job to `release.yml` calling this action for each publishable package (`packages/typescript/ui`, `.../api-client`), `permissions: { packages: write }`. Then the sport-hub pilot can consume `@chrysa/ui@0.1.0`.

Closes #235