### PR TITLE
fix(release): declare RELEASE_TOKEN in the workflow_call contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,17 @@ name: Release
 
 on:
     workflow_call:
+        secrets:
+            # Read as `secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN`, so a caller that has
+            # no PAT still works. Declaring it is what lets a caller pass it by name instead
+            # of `secrets: inherit` — an undeclared secret is simply not received, so the
+            # explicit form silently fell back to GITHUB_TOKEN and could not push a tag to a
+            # protected branch (annexe CI-021).
+            RELEASE_TOKEN:
+                description: >-
+                    PAT used to push the tag and create the release; falls back to the
+                    workflow GITHUB_TOKEN when absent.
+                required: false
 
 permissions:
     contents: write


### PR DESCRIPTION
`release.yml` reads `secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN` but its `workflow_call` block declared **no secrets at all**.

An undeclared secret is simply **not received** by a reusable workflow. So a caller doing the right thing —

```yaml
secrets:
    RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
```

— would have had it dropped, fallen back to `GITHUB_TOKEN`, and failed to push a tag to a protected branch. **Silently**, at release time.

That is why every caller uses `secrets: inherit`, which annexe [`CI-021`](https://github.com/chrysa/shared-standards/blob/main/standards/annexes/CI-CD.md) bans: it hands the callee the caller's entire secret store.

Declaring it (`required: false`, so the fallback still works for a caller with no PAT) is the **prerequisite** to replacing those inherits. Measured across the fleet: 12 files still use `secrets: inherit`; 3 of them call this workflow.

Follow-up, in this order: tag a release here, then sweep the callers.