### PR TITLE
feat(changelog): composite action wrapping git-cliff for the computed version

### DIFF
--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -1,0 +1,29 @@
+description: >-
+  Generate the release changelog with git-cliff for a version GitVersion has already
+  computed, so the notes describe the release actually being cut.
+inputs:
+  config:
+    default: cliff.toml
+    description: git-cliff configuration file (canonical, distributed by shared-standards)
+    required: false
+  version:
+    description: >-
+      Version being released, without the leading `v` — normally
+      `${{ steps.<id>.outputs.semVer }}` from the gitversion action.
+    required: true
+name: Changelog
+outputs:
+  content:
+    description: Changelog body for the release notes
+    value: ${{ steps.cliff.outputs.content }}
+runs:
+  steps:
+  # `--tag` is what makes git-cliff describe *this* release rather than the last tag it
+  # can find in the graph. Without it the notes silently belong to the previous version.
+  - id: cliff
+    name: Generate changelog
+    uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
+    with:
+      args: --latest --strip header --tag v${{ inputs.version }}
+      config: ${{ inputs.config }}
+  using: composite


### PR DESCRIPTION
`gitversion/` already exists as a composite action; its natural pair did not, so repos hand-roll the git-cliff call — `dev-nexus/release.yml` is the third occurrence. Annexe `CI-004`: the second occurrence is an extraction order.

```yaml
- id: version
  uses: chrysa/github-actions/gitversion@v1.7.0
- id: changelog
  uses: chrysa/github-actions/changelog@v1.7.0
  with:
    version: ${{ steps.version.outputs.semVer }}
```

The one detail worth centralising: **`--tag v<version>`**. Without it git-cliff describes the last tag it finds in the graph, so the release notes silently belong to the *previous* version — and nobody notices until someone reads a changelog and finds the wrong entries under a new release. Passing the version GitVersion just computed is what ties the notes to the release actually being cut.

`config` defaults to `cliff.toml`, the canonical file distributed by shared-standards.

Follow-up: consumers move onto it, starting with the three release workflows that inline this today.
