### PR TITLE
ci: pin third-party actions by commit SHA (CI-010)

### DIFF
--- a/.github/workflows/ci-fullstack.yml
+++ b/.github/workflows/ci-fullstack.yml
@@ -75,11 +75,11 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v7.0.1
-            - uses: actions/setup-python@v7.0.0
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: ${{ inputs.python-version }}
-            - uses: actions/setup-node@v7.0.0
+            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: ${{ inputs.node-version }}
             - name: Install toolchain
@@ -96,11 +96,11 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v7.0.1
-            - uses: actions/setup-python@v7.0.0
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: ${{ inputs.python-version }}
-            - uses: actions/setup-node@v7.0.0
+            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: ${{ inputs.node-version }}
             - name: Run test suite
@@ -118,7 +118,7 @@ jobs:
               shell: bash
             - name: Upload coverage
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: test-results-${{ inputs.python-version }}
                   path: reports/
@@ -134,7 +134,7 @@ jobs:
             contents: read
             pull-requests: read
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
             - name: SonarCloud scan

--- a/.github/workflows/ci-python-app.yml
+++ b/.github/workflows/ci-python-app.yml
@@ -88,7 +88,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup environment
               uses: chrysa/github-actions/tool-setup@v1.6.0
@@ -109,7 +109,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup environment
               uses: chrysa/github-actions/tool-setup@v1.6.0
@@ -132,7 +132,7 @@ jobs:
               shell: bash
 
             - name: Upload mypy report
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: mypy-report
                   path: reports/mypy.txt
@@ -144,7 +144,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Run tests via Docker (compose)
               run: make docker-test
@@ -162,7 +162,7 @@ jobs:
 
             - name: Upload test results
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: test-results-${{ inputs.latest-python }}
                   path: reports/
@@ -178,7 +178,7 @@ jobs:
             contents: read
             pull-requests: read
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -102,7 +102,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup environment
               uses: chrysa/github-actions/tool-setup@v1.6.0
@@ -125,7 +125,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup environment
               uses: chrysa/github-actions/tool-setup@v1.6.0
@@ -149,7 +149,7 @@ jobs:
               shell: bash
 
             - name: Upload mypy report
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: mypy-report
                   path: reports/mypy.txt
@@ -167,7 +167,7 @@ jobs:
             matrix:
                 python-version: ${{ fromJSON(inputs.python-versions) }}
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup environment
               uses: chrysa/github-actions/tool-setup@v1.6.0
@@ -194,7 +194,7 @@ jobs:
             contents: read
             pull-requests: read
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - uses: chrysa/github-actions/python-setup@v1.6.0
               with:
@@ -46,7 +46,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - uses: chrysa/github-actions/python-setup@v1.6.0
               with:
@@ -67,7 +67,7 @@ jobs:
         permissions:
             contents: write
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -30,7 +30,7 @@ jobs:
               if: >-
                   contains(github.event.pull_request.body, 'depends on') ||
                   contains(github.event.pull_request.body, 'blocked by')
-              uses: actions/github-script@v9
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
               with:
                   script: |
                       await github.rest.issues.addLabels({

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
             - name: Log in to GHCR
               uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
               with:
@@ -162,7 +162,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
             - name: Log in to GHCR
               uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
               with:
@@ -212,7 +212,7 @@ jobs:
               run: echo "value=${{ github.event.release.tag_name || inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
               shell: bash
             - name: Checkout catalog
-              uses: actions/checkout@v7.0.1
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   repository: ${{ inputs.catalog-repo }}
                   token: ${{ secrets.release-token }}

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -26,7 +26,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             # tool-setup = python-setup + install-project[extras]; ensures mypy
             # (language: system) and its stubs/deps are available for the replay.

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload mutmut results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mutmut-results
           path: .mutmut-cache

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,10 +19,10 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Set up Python 3.14
-              uses: actions/setup-python@v7.0.0
+              uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: '3.14'
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,8 +17,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - uses: actions/checkout@v7.0.1
-            - uses: actions/setup-python@v7.0.0
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: '3.14'
             - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -20,9 +20,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
       # `cache: npm` errors out ("Dependencies lock file is not found") on every repo
@@ -39,7 +39,7 @@ jobs:
           fi
       - name: Set up Node.js (if needed)
         continue-on-error: true
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
           cache: ${{ steps.js.outputs.cache }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         timeout-minutes: 30
         name: Create release
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
                   token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -17,7 +17,7 @@ jobs:
             contents: read
             pull-requests: read
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
             - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -29,7 +29,7 @@ jobs:
         timeout-minutes: 15
         steps:
             - name: Checkout
-              uses: actions/checkout@v7.0.1
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
             - uses: chrysa/github-actions/python-setup@v1.6.0 # v1.4.4


### PR DESCRIPTION
Third-party actions are now pinned by 40-character commit SHA, with the version kept in a trailing comment (annexe [`CI-010`](https://github.com/chrysa/shared-standards/blob/main/standards/annexes/CI-CD.md)).

A tag is a **mutable pointer**: whoever owns the action can move it, and every workflow referencing it then runs different code — with this repository's token in scope. Pinning by SHA is what makes a supply-chain change visible in a diff instead of silent.

Each SHA was resolved from the GitHub API, never guessed. Left alone on purpose: `chrysa/*` actions (`CI-011` pins those by tag so the fleet moves deliberately), local `./.github/actions/…` references, and branch refs — freezing a moving target at an arbitrary tip is a decision, not a mechanical fix.

The trailing comment keeps Dependabot able to bump these.