### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1245,7 +1245,11 @@ requires an ADR with a kill-test, not a shrug.
 
 1. **LLM-provider independence** — no vendor SDK in business code; inference goes through a
    local port with **≥2 real, tested adapters** (e.g. Claude + a local model). A prompt that
-   only works on one vendor is a bug, not a feature.
+   only works on one vendor is a bug, not a feature. **"Local model" means a model running on
+   the machine or self-hosted** — an interpreter/weights the owner runs (Ollama, llama.cpp, a
+   vLLM/TGI server on chrysa infrastructure), never a third-party hosted API dressed up as
+   "local". The independence is only proven when one of the tested adapters needs no external
+   provider to answer.
 2. **GAFAM independence** — every managed-cloud dependency has a documented self-hosted exit
    path; the cloud SDK stays confined to an adapter (`BlobStore`, not `S3Client`).
 3. **Portable personalisation data** — all user/personal data is exportable to an open format

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -44,7 +44,7 @@ class CommandSpec:
     """An ordered fallback chain of argv vectors, run without a shell.
 
     Each alternative is executed in order until one exits 0. This replaces the
-    previous single shell-interpreted string form: shell operators such as ``||``
+    previous ``shell=True`` single-string form: shell operators such as ``||``
     are no longer interpreted by a shell — fallbacks are expressed as multiple
     argv vectors instead. ``swallow_exit`` mirrors a trailing ``|| true``: the
     gate is then driven by its parsed metric rather than the tool's exit code.
@@ -150,7 +150,7 @@ class QualityGate:
         self.last_report_path = Path(self.LAST_REPORT_FILE)
 
         if not self.config_path.exists():
-            sys.stderr.write(f"ERROR: configuration file not found: {self.CONFIG_FILE}\n")
+            print(f"ERROR: configuration file not found: {self.CONFIG_FILE}")
             sys.exit(1)
 
         with open(self.config_path, encoding="utf-8") as handle:
@@ -357,7 +357,7 @@ class QualityGate:
         # not silently change whether its exit code gates. Moving security_vulns
         # into config dropped it once, and pip-audit finding a CVE failed the gate.
         spec = CommandSpec.parse(raw, swallow_exit=default_spec.swallow_exit) if raw is not None else default_spec
-        sys.stdout.write(f"RUN_GATE|{gate_name}|{spec.display()}\n")
+        print(f"RUN_GATE|{gate_name}|{spec.display()}")
         exit_code, output = self._run(spec)
         metric = self._parse_metric(gate_name, exit_code, output)
         return {
@@ -387,7 +387,7 @@ class QualityGate:
             json.dump(report, handle, indent=2)
 
     def baseline(self) -> bool:
-        sys.stdout.write("BASELINE|START\n")
+        print("BASELINE|START")
         baseline_data: dict[str, Any] = {
             "recorded_at": datetime.now().isoformat(),
             "gates": {},
@@ -402,8 +402,8 @@ class QualityGate:
                 all_ok = False
                 baseline_data["valid"] = False
             status = "PASS" if result["exit_code"] == 0 else "FAIL"
-            sys.stdout.write(
-                f"GATE_RESULT|{gate_name}|{status}|metric={result['metric']}|exit={result['exit_code']}|mode=baseline\n"
+            print(
+                f"GATE_RESULT|{gate_name}|{status}|metric={result['metric']}|exit={result['exit_code']}|mode=baseline"
             )
 
         with open(self.baseline_path, "w", encoding="utf-8") as handle:
@@ -422,15 +422,15 @@ class QualityGate:
         self._write_report(report)
 
         if all_ok:
-            sys.stdout.write("OVERALL_RESULT|PASS\n")
+            print("OVERALL_RESULT|PASS")
             return True
 
-        sys.stdout.write("OVERALL_RESULT|FAIL\n")
-        sys.stderr.write("ERROR: baseline contains failing gates; fix quality checks before using this baseline\n")
+        print("OVERALL_RESULT|FAIL")
+        print("ERROR: baseline contains failing gates; fix quality checks before using this baseline")
         return False
 
     def verify(self) -> bool:
-        sys.stdout.write("VERIFY|START\n")
+        print("VERIFY|START")
         if not self.baseline_path.exists():
             report = {
                 "mode": "verify",
@@ -439,8 +439,8 @@ class QualityGate:
                 "baseline_file": str(self.baseline_path),
             }
             self._write_report(report)
-            sys.stdout.write("OVERALL_RESULT|SKIP\n")
-            sys.stderr.write("WARNING: no baseline found — skipping regression check (run quality-gate-baseline to initialize)\n")
+            print("OVERALL_RESULT|SKIP")
+            print("WARNING: no baseline found — skipping regression check (run quality-gate-baseline to initialize)")
             return True
 
         with open(self.baseline_path, encoding="utf-8") as handle:
@@ -482,10 +482,10 @@ class QualityGate:
                 all_passed = False
 
             status = "PASS" if passed else "FAIL"
-            sys.stdout.write(
+            print(
                 f"GATE_RESULT|{gate_name}|{status}|baseline={baseline_metric}|"
                 f"target={target}|current={current_metric}|op={operator}|"
-                f"exit={current.get('exit_code', 1)}|reason={reason}\n"
+                f"exit={current.get('exit_code', 1)}|reason={reason}"
             )
 
             gate_reports.append(
@@ -513,16 +513,16 @@ class QualityGate:
         self._write_report(report)
 
         if all_passed:
-            sys.stdout.write("OVERALL_RESULT|PASS\n")
+            print("OVERALL_RESULT|PASS")
             return True
 
-        sys.stdout.write("OVERALL_RESULT|FAIL\n")
+        print("OVERALL_RESULT|FAIL")
         return False
 
 
 def main() -> None:
     if len(sys.argv) < 2:
-        sys.stderr.write("Usage: python3 quality_gate.py [baseline|verify]\n")
+        print("Usage: python3 quality_gate.py [baseline|verify]")
         sys.exit(1)
 
     command = sys.argv[1].strip().lower()
@@ -533,7 +533,7 @@ def main() -> None:
     if command == "verify":
         sys.exit(0 if quality_gate.verify() else 1)
 
-    sys.stderr.write(f"Unknown command: {command}\n")
+    print(f"Unknown command: {command}")
     sys.exit(1)
 
 


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@cdd30836b76efac52ef5237f8c7427736d0f616d`
Managed files (inline transverse standards block in `CLAUDE.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards