### PR TITLE
chore: add canonical `ci` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,3 +67,6 @@ build: ## No-op — composite actions are deployed as YAML
 
 clean: ## Remove pre-commit caches
 	pre-commit clean 2>/dev/null || true
+
+.PHONY: ci
+ci: lint typecheck test  ## CI: run all checks (lint + typecheck + test)


### PR DESCRIPTION
Adds the canonical `ci` orchestrator target to the Makefile, required by the shared-standards Makefile socle.

```make
ci: lint typecheck test  ## CI: run all checks (lint + typecheck + test)
```

Thin orchestrator of the repo's existing gate targets — no new logic. `make -n ci` parses cleanly.

Closes #269