### PR TITLE
chore(pre-commit): align print/pprint policy excludes to shared baseline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,97 +3,97 @@ default_language_version:
 fail_fast: false
 minimum_pre_commit_version: 4.1.0
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: 44d7f9b7e32225d2bd590282037e4650064f3950
-  hooks:
-  - id: check-json
-  - id: check-yaml
-    exclude: ^\.github/ISSUE_TEMPLATE/
-  - id: trailing-whitespace
-  - id: end-of-file-fixer
-  - id: detect-private-key
-  - id: no-commit-to-branch
-    args:
-    - --branch
-    - main
-- repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: 5b5dddc4fb0f83c3ea1fc5616fa63e115dce83e0
-  hooks:
-  - id: markdownlint
-    args:
-    - --fix
-    stages:
-    - manual
-- repo: https://github.com/lovesegfault/beautysh
-  rev: 34c3b3da0233e76d7d1ad90a78f3679185ecf31c
-  hooks:
-  - id: beautysh
-    args:
-    - --indent-size
-    - '4'
-- repo: https://github.com/openstack/bashate
-  rev: ec2f2400915200d633299612a02d7d285e4be24c
-  hooks:
-  - id: bashate
-    args:
-    - --ignore=E006,E020
-- repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.2.0-253
-  hooks:
-  - id: makefile-check
-  - id: yaml-sorter
-    exclude: ^(\.github/|GitVersion\.yml)
-  - id: json-sorter
-  - id: env-file-check
-  - id: adr-gate
-  - id: regression-gate
-    stages:
-    - pre-push
-  - id: env-example-sync
-  - id: claude-skill-frontmatter
-  - id: claude-agent-frontmatter
-  - id: claude-mcp-config
-  - id: python-no-unittest-import
-  - id: claude-assets-present
-  - id: python-untyped-raise
-    exclude: (^|/)tests?/
-  - id: python-mutable-default
-  - id: python-dispatch-ladder
-  - id: debugger-detection
-    exclude: (^|/)tests?/|^(README\.md|docs/)
-  - id: python-print-detection
-    exclude: (^|/)tests?/|^(README\.md|docs/)
-  - id: python-pprint-detection
-    exclude: (^|/)tests?/|^(README\.md|docs/)
-  - id: no-bare-except
-  - id: python-logger-detection
-    exclude: (^|/)tests?/|^(README\.md|docs/)
-  - id: python-unreachable-code
-  - id: no-hardcoded-localhost
-    exclude: tests?/|\.test\.|\.spec\.
-- repo: https://github.com/compilerla/conventional-pre-commit
-  rev: v4.4.0
-  hooks:
-  - id: conventional-pre-commit
-    stages:
-    - commit-msg
-    args:
-    - feat
-    - fix
-    - docs
-    - style
-    - refactor
-    - test
-    - chore
-    - perf
-    - revert
-    - ci
-- repo: https://github.com/gitleaks/gitleaks
-  rev: v8.30.1
-  hooks:
-  - id: gitleaks
-- repo: https://github.com/chrysa/guideline-checker
-  rev: v1.30.16
-  hooks:
-  - id: guideline-check
-    exclude: ^\.claude/
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 44d7f9b7e32225d2bd590282037e4650064f3950
+    hooks:
+      - id: check-json
+      - id: check-yaml
+        exclude: ^\.github/ISSUE_TEMPLATE/
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: detect-private-key
+      - id: no-commit-to-branch
+        args:
+          - --branch
+          - main
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: 5b5dddc4fb0f83c3ea1fc5616fa63e115dce83e0
+    hooks:
+      - id: markdownlint
+        args:
+          - --fix
+        stages:
+          - manual
+  - repo: https://github.com/lovesegfault/beautysh
+    rev: 34c3b3da0233e76d7d1ad90a78f3679185ecf31c
+    hooks:
+      - id: beautysh
+        args:
+          - --indent-size
+          - '4'
+  - repo: https://github.com/openstack/bashate
+    rev: ec2f2400915200d633299612a02d7d285e4be24c
+    hooks:
+      - id: bashate
+        args:
+          - --ignore=E006,E020
+  - repo: https://github.com/chrysa/pre-commit-tools
+    rev: v0.2.0-253
+    hooks:
+      - id: makefile-check
+      - id: yaml-sorter
+        exclude: ^(\.github/|GitVersion\.yml)
+      - id: json-sorter
+      - id: env-file-check
+      - id: adr-gate
+      - id: regression-gate
+        stages:
+          - pre-push
+      - id: env-example-sync
+      - id: claude-skill-frontmatter
+      - id: claude-agent-frontmatter
+      - id: claude-mcp-config
+      - id: python-no-unittest-import
+      - id: claude-assets-present
+      - id: python-untyped-raise
+        exclude: '(^|/)tests?/'
+      - id: python-mutable-default
+      - id: python-dispatch-ladder
+      - id: debugger-detection
+        exclude: '(^|/)tests?/|^(README\.md|docs/)'
+      - id: python-print-detection
+        exclude: '(^|/)tests?/|^(README\.md|docs/)|(^|/)quality_gate\.py$|^\.claude/ape/'
+      - id: python-pprint-detection
+        exclude: '(^|/)tests?/|^(README\.md|docs/)|(^|/)quality_gate\.py$|^\.claude/ape/'
+      - id: no-bare-except
+      - id: python-logger-detection
+        exclude: '(^|/)tests?/|^(README\.md|docs/)'
+      - id: python-unreachable-code
+      - id: no-hardcoded-localhost
+        exclude: tests?/|\.test\.|\.spec\.
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages:
+          - commit-msg
+        args:
+          - feat
+          - fix
+          - docs
+          - style
+          - refactor
+          - test
+          - chore
+          - perf
+          - revert
+          - ci
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+  - repo: https://github.com/chrysa/guideline-checker
+    rev: v1.30.16
+    hooks:
+      - id: guideline-check
+        exclude: ^\.claude/


### PR DESCRIPTION
Aligns `python-print-detection` + `python-pprint-detection` policy excludes to the shared-standards baseline (adds `quality_gate.py` + `.claude/ape/`). Fleet standards sync via pre-commit-merge.py.