### PR TITLE
fix: pin actions/setup-node to SHA in publish-node-package (#276)

### DIFF
--- a/publish-node-package/action.yml
+++ b/publish-node-package/action.yml
@@ -18,7 +18,7 @@ name: Publish Node package
 runs:
   steps:
   - name: Set up Node.js
-    uses: actions/setup-node@v4
+    uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
     with:
       node-version: ${{ inputs.node-version }}
       registry-url: https://npm.pkg.github.com


### PR DESCRIPTION
Pin `actions/setup-node` to `820762786026740c76f36085b0efc47a31fe5020 # v7.0.0`, matching the rest of the repo. Supply-chain hardening.

Closes #276.